### PR TITLE
Remove unnecessary calls to escaping functions

### DIFF
--- a/404.php
+++ b/404.php
@@ -14,11 +14,11 @@ get_header(); ?>
 
 			<section class="error-404 not-found">
 				<header class="page-header">
-					<h1 class="page-title"><?php esc_html_e( 'Oops! That page can&rsquo;t be found.', 'twentysixteen' ); ?></h1>
+					<h1 class="page-title"><?php _e( 'Oops! That page can&rsquo;t be found.', 'twentysixteen' ); ?></h1>
 				</header><!-- .page-header -->
 
 				<div class="page-content">
-					<p><?php esc_html_e( 'It looks like nothing was found at this location. Maybe try a search?', 'twentysixteen' ); ?></p>
+					<p><?php _e( 'It looks like nothing was found at this location. Maybe try a search?', 'twentysixteen' ); ?></p>
 
 					<?php get_search_form(); ?>
 				</div><!-- .page-content -->

--- a/archive.php
+++ b/archive.php
@@ -46,9 +46,9 @@ get_header(); ?>
 			if ( have_posts() ) :
 				// Previous/next page navigation.
 				the_posts_pagination( array(
-					'prev_text'          => esc_html__( 'Previous page', 'twentysixteen' ),
-					'next_text'          => esc_html__( 'Next page', 'twentysixteen' ),
-					'before_page_number' => '<span class="meta-nav screen-reader-text">' . esc_html__( 'Page', 'twentysixteen' ) . ' </span>',
+					'prev_text'          => __( 'Previous page', 'twentysixteen' ),
+					'next_text'          => __( 'Next page', 'twentysixteen' ),
+					'before_page_number' => '<span class="meta-nav screen-reader-text">' . __( 'Page', 'twentysixteen' ) . ' </span>',
 				) );
 			endif;
 

--- a/comments.php
+++ b/comments.php
@@ -50,7 +50,7 @@ if ( post_password_required() ) {
 		// If comments are closed and there are comments, let's leave a little note, shall we?
 		if ( ! comments_open() && get_comments_number() && post_type_supports( get_post_type(), 'comments' ) ) :
 	?>
-		<p class="no-comments"><?php esc_html_e( 'Comments are closed.', 'twentysixteen' ); ?></p>
+		<p class="no-comments"><?php _e( 'Comments are closed.', 'twentysixteen' ); ?></p>
 	<?php endif; ?>
 
 	<?php comment_form(); ?>

--- a/footer.php
+++ b/footer.php
@@ -48,7 +48,7 @@
 					do_action( 'twentysixteen_credits' );
 				?>
 				<span class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></span>
-				<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'twentysixteen' ) ); ?>"><?php printf( esc_html__( 'Proudly powered by %s', 'twentysixteen' ), 'WordPress' ); ?></a>
+				<a href="<?php echo esc_url( __( 'https://wordpress.org/', 'twentysixteen' ) ); ?>"><?php printf( __( 'Proudly powered by %s', 'twentysixteen' ), 'WordPress' ); ?></a>
 			</div><!-- .site-info -->
 		</footer><!-- .site-footer -->
 	</div><!-- .site-inner -->

--- a/functions.php
+++ b/functions.php
@@ -70,8 +70,8 @@ function twentysixteen_setup() {
 
 	// This theme uses wp_nav_menu() in one location.
 	register_nav_menus( array(
-		'primary' => esc_html__( 'Primary Menu', 'twentysixteen' ),
-		'social'  => esc_html__( 'Social Links Menu', 'twentysixteen' ),
+		'primary' => __( 'Primary Menu', 'twentysixteen' ),
+		'social'  => __( 'Social Links Menu', 'twentysixteen' ),
 	) );
 
 	/*
@@ -123,7 +123,7 @@ add_action( 'after_setup_theme', 'twentysixteen_content_width', 0 );
  */
 function twentysixteen_widgets_init() {
 	register_sidebar( array(
-		'name'          => esc_html__( 'Sidebar', 'twentysixteen' ),
+		'name'          => __( 'Sidebar', 'twentysixteen' ),
 		'id'            => 'sidebar-1',
 		'description'   => '',
 		'before_widget' => '<aside id="%1$s" class="widget %2$s">',
@@ -133,9 +133,9 @@ function twentysixteen_widgets_init() {
 	) );
 
 	register_sidebar( array(
-		'name'          => esc_html__( 'Content Bottom 1', 'twentysixteen' ),
+		'name'          => __( 'Content Bottom 1', 'twentysixteen' ),
 		'id'            => 'sidebar-2',
-		'description'   => esc_html__( 'Appears at the bottom of the content on posts and pages.', 'twentysixteen' ),
+		'description'   => __( 'Appears at the bottom of the content on posts and pages.', 'twentysixteen' ),
 		'before_widget' => '<aside id="%1$s" class="widget %2$s">',
 		'after_widget'  => '</aside>',
 		'before_title'  => '<h2 class="widget-title">',
@@ -143,9 +143,9 @@ function twentysixteen_widgets_init() {
 	) );
 
 	register_sidebar( array(
-		'name'          => esc_html__( 'Content Bottom 2', 'twentysixteen' ),
+		'name'          => __( 'Content Bottom 2', 'twentysixteen' ),
 		'id'            => 'sidebar-3',
-		'description'   => esc_html__( 'Appears at the bottom of the content on posts and pages.', 'twentysixteen' ),
+		'description'   => __( 'Appears at the bottom of the content on posts and pages.', 'twentysixteen' ),
 		'before_widget' => '<aside id="%1$s" class="widget %2$s">',
 		'after_widget'  => '</aside>',
 		'before_title'  => '<h2 class="widget-title">',
@@ -168,17 +168,17 @@ function twentysixteen_fonts_url() {
 	$subsets   = 'latin,latin-ext';
 
 	/* translators: If there are characters in your language that are not supported by Merriweather, translate this to 'off'. Do not translate into your own language. */
-	if ( 'off' !== esc_html_x( 'on', 'Merriweather font: on or off', 'twentysixteen' ) ) {
+	if ( 'off' !== _x( 'on', 'Merriweather font: on or off', 'twentysixteen' ) ) {
 		$fonts[] = 'Merriweather:400,700,900,400italic,700italic,900italic';
 	}
 
 	/* translators: If there are characters in your language that are not supported by Montserrat, translate this to 'off'. Do not translate into your own language. */
-	if ( 'off' !== esc_html_x( 'on', 'Montserrat font: on or off', 'twentysixteen' ) ) {
+	if ( 'off' !== _x( 'on', 'Montserrat font: on or off', 'twentysixteen' ) ) {
 		$fonts[] = 'Montserrat:400,700';
 	}
 
 	/* translators: If there are characters in your language that are not supported by Inconsolata, translate this to 'off'. Do not translate into your own language. */
-	if ( 'off' !== esc_html_x( 'on', 'Inconsolata font: on or off', 'twentysixteen' ) ) {
+	if ( 'off' !== _x( 'on', 'Inconsolata font: on or off', 'twentysixteen' ) ) {
 		$fonts[] = 'Inconsolata:400';
 	}
 
@@ -242,8 +242,8 @@ function twentysixteen_scripts() {
 	wp_enqueue_script( 'twentysixteen-script', get_template_directory_uri() . '/js/functions.js', array( 'jquery' ), '20150825', true );
 
 	wp_localize_script( 'twentysixteen-script', 'screenReaderText', array(
-		'expand'   => '<span class="screen-reader-text">' . esc_html__( 'expand child menu', 'twentysixteen' ) . '</span>',
-		'collapse' => '<span class="screen-reader-text">' . esc_html__( 'collapse child menu', 'twentysixteen' ) . '</span>',
+		'expand'   => '<span class="screen-reader-text">' . __( 'expand child menu', 'twentysixteen' ) . '</span>',
+		'collapse' => '<span class="screen-reader-text">' . __( 'collapse child menu', 'twentysixteen' ) . '</span>',
 	) );
 }
 add_action( 'wp_enqueue_scripts', 'twentysixteen_scripts' );

--- a/header.php
+++ b/header.php
@@ -75,7 +75,7 @@
 			<?php if ( get_header_image() ) : ?>
 				<div class="header-image">
 					<a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
-						<img src="<?php header_image(); ?>" width="<?php echo absint( get_custom_header()->width ); ?>" height="<?php echo absint( get_custom_header()->height ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>">
+						<img src="<?php header_image(); ?>" width="<?php echo esc_attr( get_custom_header()->width ); ?>" height="<?php echo esc_attr( get_custom_header()->height ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>">
 					</a>
 				</div>
 			<?php endif; // End header image check. ?>

--- a/header.php
+++ b/header.php
@@ -21,7 +21,7 @@
 <body <?php body_class(); ?>>
 <div id="page" class="hfeed site">
 	<div class="site-inner">
-		<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'twentysixteen' ); ?></a>
+		<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'twentysixteen' ); ?></a>
 
 		<header id="masthead" class="site-header" role="banner">
 			<div class="site-header-main">
@@ -39,7 +39,7 @@
 				</div><!-- .site-branding -->
 
 				<?php if ( has_nav_menu( 'primary' ) || has_nav_menu( 'social' ) ) : ?>
-					<button id="menu-toggle" class="menu-toggle"><?php esc_html_e( 'Menu', 'twentysixteen' ); ?></button>
+					<button id="menu-toggle" class="menu-toggle"><?php _e( 'Menu', 'twentysixteen' ); ?></button>
 				<?php endif; ?>
 
 				<?php if ( has_nav_menu( 'primary' ) || has_nav_menu( 'social' ) ) : ?>

--- a/image.php
+++ b/image.php
@@ -21,8 +21,8 @@ get_header(); ?>
 
 					<nav id="image-navigation" class="navigation image-navigation">
 						<div class="nav-links">
-							<div class="nav-previous"><?php previous_image_link( false, esc_html__( 'Previous Image', 'twentysixteen' ) ); ?></div>
-							<div class="nav-next"><?php next_image_link( false, esc_html__( 'Next Image', 'twentysixteen' ) ); ?></div>
+							<div class="nav-previous"><?php previous_image_link( false, __( 'Previous Image', 'twentysixteen' ) ); ?></div>
+							<div class="nav-next"><?php next_image_link( false, __( 'Next Image', 'twentysixteen' ) ); ?></div>
 						</div><!-- .nav-links -->
 					</nav><!-- .image-navigation -->
 
@@ -57,11 +57,11 @@ get_header(); ?>
 						<?php
 							the_content();
 							wp_link_pages( array(
-								'before'      => '<div class="page-links"><span class="page-links-title">' . esc_html__( 'Pages:', 'twentysixteen' ) . '</span>',
+								'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'twentysixteen' ) . '</span>',
 								'after'       => '</div>',
 								'link_before' => '<span>',
 								'link_after'  => '</span>',
-								'pagelink'    => '<span class="screen-reader-text">' . esc_html__( 'Page', 'twentysixteen' ) . ' </span>%',
+								'pagelink'    => '<span class="screen-reader-text">' . __( 'Page', 'twentysixteen' ) . ' </span>%',
 								'separator'   => '<span class="screen-reader-text">, </span>',
 							) );
 						?>
@@ -74,14 +74,14 @@ get_header(); ?>
 							$metadata = wp_get_attachment_metadata();
 							if ( $metadata ) {
 								printf( '<span class="full-size-link"><span class="screen-reader-text">%1$s </span><a href="%2$s">%3$s &times; %4$s</a></span>',
-									esc_html_x( 'Full size', 'Used before full size attachment link.', 'twentysixteen' ),
+									_x( 'Full size', 'Used before full size attachment link.', 'twentysixteen' ),
 									esc_url( wp_get_attachment_url() ),
 									absint( $metadata['width'] ),
 									absint( $metadata['height'] )
 								);
 							}
 						?>
-						<?php edit_post_link( esc_html__( 'Edit', 'twentysixteen' ), '<span class="edit-link">', '</span>' ); ?>
+						<?php edit_post_link( __( 'Edit', 'twentysixteen' ), '<span class="edit-link">', '</span>' ); ?>
 					</footer><!-- .entry-footer -->
 				</article><!-- #post-## -->
 

--- a/inc/back-compat.php
+++ b/inc/back-compat.php
@@ -34,7 +34,7 @@ add_action( 'after_switch_theme', 'twentysixteen_switch_theme' );
  * @since Twenty Sixteen 1.0
  */
 function twentysixteen_upgrade_notice() {
-	$message = sprintf( esc_html__( 'Twenty Sixteen requires at least WordPress version 4.2. You are running version %s. Please upgrade and try again.', 'twentysixteen' ), $GLOBALS['wp_version'] );
+	$message = sprintf( __( 'Twenty Sixteen requires at least WordPress version 4.2. You are running version %s. Please upgrade and try again.', 'twentysixteen' ), $GLOBALS['wp_version'] );
 	printf( '<div class="error"><p>%s</p></div>', $message );
 }
 
@@ -44,7 +44,7 @@ function twentysixteen_upgrade_notice() {
  * @since Twenty Sixteen 1.0
  */
 function twentysixteen_customize() {
-	wp_die( sprintf( esc_html__( 'Twenty Sixteen requires at least WordPress version 4.2. You are running version %s. Please upgrade and try again.', 'twentysixteen' ), $GLOBALS['wp_version'] ), '', array(
+	wp_die( sprintf( __( 'Twenty Sixteen requires at least WordPress version 4.2. You are running version %s. Please upgrade and try again.', 'twentysixteen' ), $GLOBALS['wp_version'] ), '', array(
 		'back_link' => true,
 	) );
 }
@@ -57,7 +57,7 @@ add_action( 'load-customize.php', 'twentysixteen_customize' );
  */
 function twentysixteen_preview() {
 	if ( isset( $_GET['preview'] ) ) {
-		wp_die( sprintf( esc_html__( 'Twenty Sixteen requires at least WordPress version 4.2. You are running version %s. Please upgrade and try again.', 'twentysixteen' ), $GLOBALS['wp_version'] ) );
+		wp_die( sprintf( __( 'Twenty Sixteen requires at least WordPress version 4.2. You are running version %s. Please upgrade and try again.', 'twentysixteen' ), $GLOBALS['wp_version'] ) );
 	}
 }
 add_action( 'template_redirect', 'twentysixteen_preview' );

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -28,7 +28,7 @@ function twentysixteen_customize_register( $wp_customize ) {
 	) );
 
 	$wp_customize->add_control( 'color_scheme', array(
-		'label'    => esc_html__( 'Base Color Scheme', 'twentysixteen' ),
+		'label'    => __( 'Base Color Scheme', 'twentysixteen' ),
 		'section'  => 'colors',
 		'type'     => 'select',
 		'choices'  => twentysixteen_get_color_scheme_choices(),
@@ -43,7 +43,7 @@ function twentysixteen_customize_register( $wp_customize ) {
 	) );
 
 	$wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'page_background_color', array(
-		'label'       => esc_html__( 'Page Background Color', 'twentysixteen' ),
+		'label'       => __( 'Page Background Color', 'twentysixteen' ),
 		'section'     => 'colors',
 	) ) );
 
@@ -58,7 +58,7 @@ function twentysixteen_customize_register( $wp_customize ) {
 	) );
 
 	$wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'link_color', array(
-		'label'       => esc_html__( 'Link Color', 'twentysixteen' ),
+		'label'       => __( 'Link Color', 'twentysixteen' ),
 		'section'     => 'colors',
 	) ) );
 
@@ -70,7 +70,7 @@ function twentysixteen_customize_register( $wp_customize ) {
 	) );
 
 	$wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'main_text_color', array(
-		'label'       => esc_html__( 'Main Text Color', 'twentysixteen' ),
+		'label'       => __( 'Main Text Color', 'twentysixteen' ),
 		'section'     => 'colors',
 	) ) );
 
@@ -82,7 +82,7 @@ function twentysixteen_customize_register( $wp_customize ) {
 	) );
 
 	$wp_customize->add_control( new WP_Customize_Color_Control( $wp_customize, 'secondary_text_color', array(
-		'label'       => esc_html__( 'Secondary Text Color', 'twentysixteen' ),
+		'label'       => __( 'Secondary Text Color', 'twentysixteen' ),
 		'section'     => 'colors',
 	) ) );
 }
@@ -107,7 +107,7 @@ add_action( 'customize_register', 'twentysixteen_customize_register', 11 );
 function twentysixteen_get_color_schemes() {
 	return apply_filters( 'twentysixteen_color_schemes', array(
 		'default' => array(
-			'label'  => esc_html__( 'Default', 'twentysixteen' ),
+			'label'  => __( 'Default', 'twentysixteen' ),
 			'colors' => array(
 				'#1a1a1a',
 				'#ffffff',
@@ -117,7 +117,7 @@ function twentysixteen_get_color_schemes() {
 			),
 		),
 		'dark' => array(
-			'label'  => esc_html__( 'Dark', 'twentysixteen' ),
+			'label'  => __( 'Dark', 'twentysixteen' ),
 			'colors' => array(
 				'#262626',
 				'#1a1a1a',
@@ -127,7 +127,7 @@ function twentysixteen_get_color_schemes() {
 			),
 		),
 		'gray' => array(
-			'label'  => esc_html__( 'Gray', 'twentysixteen' ),
+			'label'  => __( 'Gray', 'twentysixteen' ),
 			'colors' => array(
 				'#616a73',
 				'#4d545c',
@@ -137,7 +137,7 @@ function twentysixteen_get_color_schemes() {
 			),
 		),
 		'green' => array(
-			'label'  => esc_html__( 'Green', 'twentysixteen' ),
+			'label'  => __( 'Green', 'twentysixteen' ),
 			'colors' => array(
 				'#ffffff',
 				'#acc1a2',
@@ -147,7 +147,7 @@ function twentysixteen_get_color_schemes() {
 			),
 		),
 		'yellow' => array(
-			'label'  => esc_html__( 'Yellow', 'twentysixteen' ),
+			'label'  => __( 'Yellow', 'twentysixteen' ),
 			'colors' => array(
 				'#3b3721',
 				'#ffef8e',

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -23,11 +23,11 @@ function twentysixteen_comment_nav() {
 		<h2 class="screen-reader-text"><?php _e( 'Comment navigation', 'twentysixteen' ); ?></h2>
 		<div class="nav-links">
 			<?php
-				if ( $prev_link = get_previous_comments_link( esc_html__( 'Older Comments', 'twentysixteen' ) ) ) :
+				if ( $prev_link = get_previous_comments_link( __( 'Older Comments', 'twentysixteen' ) ) ) :
 					printf( '<div class="nav-previous">%s</div>', $prev_link );
 				endif;
 
-				if ( $next_link = get_next_comments_link( esc_html__( 'Newer Comments', 'twentysixteen' ) ) ) :
+				if ( $next_link = get_next_comments_link( __( 'Newer Comments', 'twentysixteen' ) ) ) :
 					printf( '<div class="nav-next">%s</div>', $next_link );
 				endif;
 			?>
@@ -51,7 +51,7 @@ function twentysixteen_entry_meta() {
 		$author_avatar_size = apply_filters( 'twentysixteen_author_avatar_size', 49 );
 		printf( '<span class="byline"><span class="author vcard">%1$s<span class="screen-reader-text">%2$s </span> <a class="url fn n" href="%3$s">%4$s</a></span></span>',
 			get_avatar( get_the_author_meta( 'user_email' ), $author_avatar_size ),
-			esc_html_x( 'Author', 'Used before post author name.', 'twentysixteen' ),
+			_x( 'Author', 'Used before post author name.', 'twentysixteen' ),
 			esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
 			esc_html( get_the_author() )
 		);
@@ -64,7 +64,7 @@ function twentysixteen_entry_meta() {
 	$format = get_post_format();
 	if ( current_theme_supports( 'post-formats', $format ) ) {
 		printf( '<span class="entry-format">%1$s<a href="%2$s">%3$s</a></span>',
-			sprintf( '<span class="screen-reader-text">%s </span>', esc_html_x( 'Format', 'Used before post format.', 'twentysixteen' ) ),
+			sprintf( '<span class="screen-reader-text">%s </span>', _x( 'Format', 'Used before post format.', 'twentysixteen' ) ),
 			esc_url( get_post_format_link( $format ) ),
 			esc_html( get_post_format_string( $format ) )
 		);
@@ -105,7 +105,7 @@ function twentysixteen_entry_date() {
 	);
 
 	printf( '<span class="posted-on"><span class="screen-reader-text">%1$s </span><a href="%2$s" rel="bookmark">%3$s</a></span>',
-		esc_html_x( 'Posted on', 'Used before publish date.', 'twentysixteen' ),
+		_x( 'Posted on', 'Used before publish date.', 'twentysixteen' ),
 		esc_url( get_permalink() ),
 		$time_string
 	);
@@ -121,18 +121,18 @@ if ( ! function_exists( 'twentysixteen_entry_taxonomies' ) ) :
  * @since Twenty Sixteen 1.0
  */
 function twentysixteen_entry_taxonomies() {
-	$categories_list = get_the_category_list( esc_html_x( ', ', 'Used between list items, there is a space after the comma.', 'twentysixteen' ) );
+	$categories_list = get_the_category_list( _x( ', ', 'Used between list items, there is a space after the comma.', 'twentysixteen' ) );
 	if ( $categories_list && twentysixteen_categorized_blog() ) {
 		printf( '<span class="cat-links"><span class="screen-reader-text">%1$s </span>%2$s</span>',
-			esc_html_x( 'Categories', 'Used before category names.', 'twentysixteen' ),
+			_x( 'Categories', 'Used before category names.', 'twentysixteen' ),
 			$categories_list
 		);
 	}
 
-	$tags_list = get_the_tag_list( '', esc_html_x( ', ', 'Used between list items, there is a space after the comma.', 'twentysixteen' ) );
+	$tags_list = get_the_tag_list( '', _x( ', ', 'Used between list items, there is a space after the comma.', 'twentysixteen' ) );
 	if ( $tags_list ) {
 		printf( '<span class="tags-links"><span class="screen-reader-text">%1$s </span>%2$s</span>',
-			esc_html_x( 'Tags', 'Used before tag names.', 'twentysixteen' ),
+			_x( 'Tags', 'Used before tag names.', 'twentysixteen' ),
 			$tags_list
 		);
 	}
@@ -183,7 +183,7 @@ function twentysixteen_excerpt_more( $more ) {
 		esc_url( get_permalink( get_the_ID() ) ),
 		/* translators: %s: Name of current post */
 		sprintf( __( 'Continue reading %s', 'twentysixteen' ), '<span class="screen-reader-text">' . esc_html( get_the_title( get_the_ID() ) ) . '</span>' )
-		);
+	);
 	return ' &hellip; ' . $link;
 }
 add_filter( 'excerpt_more', 'twentysixteen_excerpt_more' );

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -53,7 +53,7 @@ function twentysixteen_entry_meta() {
 			get_avatar( get_the_author_meta( 'user_email' ), $author_avatar_size ),
 			_x( 'Author', 'Used before post author name.', 'twentysixteen' ),
 			esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),
-			esc_html( get_the_author() )
+			get_the_author()
 		);
 	}
 
@@ -66,7 +66,7 @@ function twentysixteen_entry_meta() {
 		printf( '<span class="entry-format">%1$s<a href="%2$s">%3$s</a></span>',
 			sprintf( '<span class="screen-reader-text">%s </span>', _x( 'Format', 'Used before post format.', 'twentysixteen' ) ),
 			esc_url( get_post_format_link( $format ) ),
-			esc_html( get_post_format_string( $format ) )
+			get_post_format_string( $format )
 		);
 	}
 
@@ -99,9 +99,9 @@ function twentysixteen_entry_date() {
 
 	$time_string = sprintf( $time_string,
 		esc_attr( get_the_date( 'c' ) ),
-		esc_html( get_the_date() ),
+		get_the_date(),
 		esc_attr( get_the_modified_date( 'c' ) ),
-		esc_html( get_the_modified_date() )
+		get_the_modified_date()
 	);
 
 	printf( '<span class="posted-on"><span class="screen-reader-text">%1$s </span><a href="%2$s" rel="bookmark">%3$s</a></span>',
@@ -182,7 +182,7 @@ function twentysixteen_excerpt_more( $more ) {
 	$link = sprintf( '<a href="%1$s" class="more-link">%2$s</a>',
 		esc_url( get_permalink( get_the_ID() ) ),
 		/* translators: %s: Name of current post */
-		sprintf( __( 'Continue reading %s', 'twentysixteen' ), '<span class="screen-reader-text">' . esc_html( get_the_title( get_the_ID() ) ) . '</span>' )
+		sprintf( __( 'Continue reading %s', 'twentysixteen' ), '<span class="screen-reader-text">' . get_the_title( get_the_ID() ) . '</span>' )
 	);
 	return ' &hellip; ' . $link;
 }

--- a/index.php
+++ b/index.php
@@ -42,9 +42,9 @@ get_header(); ?>
 
 			// Previous/next page navigation.
 			the_posts_pagination( array(
-				'prev_text'          => esc_html__( 'Previous page', 'twentysixteen' ),
-				'next_text'          => esc_html__( 'Next page', 'twentysixteen' ),
-				'before_page_number' => '<span class="meta-nav screen-reader-text">' . esc_html__( 'Page', 'twentysixteen' ) . ' </span>',
+				'prev_text'          => __( 'Previous page', 'twentysixteen' ),
+				'next_text'          => __( 'Next page', 'twentysixteen' ),
+				'before_page_number' => '<span class="meta-nav screen-reader-text">' . __( 'Page', 'twentysixteen' ) . ' </span>',
 			) );
 
 		// If no content, include the "No posts found" template.

--- a/search.php
+++ b/search.php
@@ -15,7 +15,7 @@ get_header(); ?>
 		<?php if ( have_posts() ) : ?>
 
 			<header class="page-header">
-				<h1 class="page-title"><?php printf( esc_html__( 'Search Results for: %s', 'twentysixteen' ), '<span>' . esc_html( get_search_query() ) . '</span>' ); ?></h1>
+				<h1 class="page-title"><?php printf( __( 'Search Results for: %s', 'twentysixteen' ), '<span>' . esc_html( get_search_query() ) . '</span>' ); ?></h1>
 			</header><!-- .page-header -->
 
 			<?php
@@ -34,9 +34,9 @@ get_header(); ?>
 
 			// Previous/next page navigation.
 			the_posts_pagination( array(
-				'prev_text'          => esc_html__( 'Previous page', 'twentysixteen' ),
-				'next_text'          => esc_html__( 'Next page', 'twentysixteen' ),
-				'before_page_number' => '<span class="meta-nav screen-reader-text">' . esc_html__( 'Page', 'twentysixteen' ) . ' </span>',
+				'prev_text'          => __( 'Previous page', 'twentysixteen' ),
+				'next_text'          => __( 'Next page', 'twentysixteen' ),
+				'before_page_number' => '<span class="meta-nav screen-reader-text">' . __( 'Page', 'twentysixteen' ) . ' </span>',
 			) );
 
 		// If no content, include the "No posts found" template.

--- a/single.php
+++ b/single.php
@@ -25,11 +25,11 @@ get_header(); ?>
 
 			// Previous/next post navigation.
 			the_post_navigation( array(
-				'next_text' => '<span class="meta-nav" aria-hidden="true">' . esc_html__( 'Next', 'twentysixteen' ) . '</span> ' .
-					'<span class="screen-reader-text">' . esc_html__( 'Next post:', 'twentysixteen' ) . '</span> ' .
+				'next_text' => '<span class="meta-nav" aria-hidden="true">' . __( 'Next', 'twentysixteen' ) . '</span> ' .
+					'<span class="screen-reader-text">' . __( 'Next post:', 'twentysixteen' ) . '</span> ' .
 					'<span class="post-title">%title</span>',
-				'prev_text' => '<span class="meta-nav" aria-hidden="true">' . esc_html__( 'Previous', 'twentysixteen' ) . '</span> ' .
-					'<span class="screen-reader-text">' . esc_html__( 'Previous post:', 'twentysixteen' ) . '</span> ' .
+				'prev_text' => '<span class="meta-nav" aria-hidden="true">' . __( 'Previous', 'twentysixteen' ) . '</span> ' .
+					'<span class="screen-reader-text">' . __( 'Previous post:', 'twentysixteen' ) . '</span> ' .
 					'<span class="post-title">%title</span>',
 			) );
 

--- a/template-parts/biography.php
+++ b/template-parts/biography.php
@@ -30,7 +30,7 @@
 		<p class="author-bio">
 			<?php the_author_meta( 'description' ); ?>
 			<a class="author-link" href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
-				<?php printf( esc_html__( 'View all posts by %s', 'twentysixteen' ), esc_html( get_the_author() ) ); ?>
+				<?php printf( __( 'View all posts by %s', 'twentysixteen' ), esc_html( get_the_author() ) ); ?>
 			</a>
 		</p><!-- .author-bio -->
 	</div><!-- .author-description -->

--- a/template-parts/biography.php
+++ b/template-parts/biography.php
@@ -25,12 +25,12 @@
 	</div><!-- .author-avatar -->
 
 	<div class="author-description">
-		<h3 class="author-title"><span class="author-heading"><?php _e( 'Author:', 'twentysixteen' ); ?></span> <?php echo esc_html( get_the_author() ); ?></h3>
+		<h3 class="author-title"><span class="author-heading"><?php _e( 'Author:', 'twentysixteen' ); ?></span> <?php the_author(); ?></h3>
 
 		<p class="author-bio">
 			<?php the_author_meta( 'description' ); ?>
 			<a class="author-link" href="<?php echo esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ); ?>" rel="author">
-				<?php printf( __( 'View all posts by %s', 'twentysixteen' ), esc_html( get_the_author() ) ); ?>
+				<?php printf( __( 'View all posts by %s', 'twentysixteen' ), get_the_author() ); ?>
 			</a>
 		</p><!-- .author-bio -->
 	</div><!-- .author-description -->

--- a/template-parts/content-none.php
+++ b/template-parts/content-none.php
@@ -12,22 +12,22 @@
 
 <section class="no-results not-found">
 	<header class="page-header">
-		<h1 class="page-title"><?php esc_html_e( 'Nothing Found', 'twentysixteen' ); ?></h1>
+		<h1 class="page-title"><?php _e( 'Nothing Found', 'twentysixteen' ); ?></h1>
 	</header><!-- .page-header -->
 
 	<div class="page-content">
 		<?php if ( is_home() && current_user_can( 'publish_posts' ) ) : ?>
 
-			<p><?php printf( wp_kses( __( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'twentysixteen' ), array( 'a' => array( 'href' => array() ) ) ), esc_url( admin_url( 'post-new.php' ) ) ); ?></p>
+			<p><?php printf( __( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'twentysixteen' ), esc_url( admin_url( 'post-new.php' ) ) ); ?></p>
 
 		<?php elseif ( is_search() ) : ?>
 
-			<p><?php esc_html_e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'twentysixteen' ); ?></p>
+			<p><?php _e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'twentysixteen' ); ?></p>
 			<?php get_search_form(); ?>
 
 		<?php else : ?>
 
-			<p><?php esc_html_e( 'It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps searching can help.', 'twentysixteen' ); ?></p>
+			<p><?php _e( 'It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps searching can help.', 'twentysixteen' ); ?></p>
 			<?php get_search_form(); ?>
 
 		<?php endif; ?>

--- a/template-parts/content-page.php
+++ b/template-parts/content-page.php
@@ -20,16 +20,16 @@
 		the_content();
 
 		wp_link_pages( array(
-			'before'      => '<div class="page-links"><span class="page-links-title">' . esc_html__( 'Pages:', 'twentysixteen' ) . '</span>',
+			'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'twentysixteen' ) . '</span>',
 			'after'       => '</div>',
 			'link_before' => '<span>',
 			'link_after'  => '</span>',
-			'pagelink'    => '<span class="screen-reader-text">' . esc_html__( 'Page', 'twentysixteen' ) . ' </span>%',
+			'pagelink'    => '<span class="screen-reader-text">' . __( 'Page', 'twentysixteen' ) . ' </span>%',
 			'separator'   => '<span class="screen-reader-text">, </span>',
 		) );
 		?>
 	</div><!-- .entry-content -->
 
-	<?php edit_post_link( esc_html__( 'Edit', 'twentysixteen' ), '<footer class="entry-footer"><span class="edit-link">', '</span></footer><!-- .entry-footer -->' ); ?>
+	<?php edit_post_link( __( 'Edit', 'twentysixteen' ), '<footer class="entry-footer"><span class="edit-link">', '</span></footer><!-- .entry-footer -->' ); ?>
 
 </article><!-- #post-## -->

--- a/template-parts/content-search.php
+++ b/template-parts/content-search.php
@@ -25,12 +25,12 @@
 
 		<footer class="entry-footer">
 			<?php twentysixteen_entry_meta(); ?>
-			<?php edit_post_link( esc_html__( 'Edit', 'twentysixteen' ), '<span class="edit-link">', '</span>' ); ?>
+			<?php edit_post_link( __( 'Edit', 'twentysixteen' ), '<span class="edit-link">', '</span>' ); ?>
 		</footer><!-- .entry-footer -->
 
 	<?php else : ?>
 
-		<?php edit_post_link( esc_html__( 'Edit', 'twentysixteen' ), '<footer class="entry-footer"><span class="edit-link">', '</span></footer><!-- .entry-footer -->' ); ?>
+		<?php edit_post_link( __( 'Edit', 'twentysixteen' ), '<footer class="entry-footer"><span class="edit-link">', '</span></footer><!-- .entry-footer -->' ); ?>
 
 	<?php endif; ?>
 </article><!-- #post-## -->

--- a/template-parts/content-single.php
+++ b/template-parts/content-single.php
@@ -26,11 +26,11 @@
 			the_content();
 
 			wp_link_pages( array(
-				'before'      => '<div class="page-links"><span class="page-links-title">' . esc_html__( 'Pages:', 'twentysixteen' ) . '</span>',
+				'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'twentysixteen' ) . '</span>',
 				'after'       => '</div>',
 				'link_before' => '<span>',
 				'link_after'  => '</span>',
-				'pagelink'    => '<span class="screen-reader-text">' . esc_html__( 'Page', 'twentysixteen' ) . ' </span>%',
+				'pagelink'    => '<span class="screen-reader-text">' . __( 'Page', 'twentysixteen' ) . ' </span>%',
 				'separator'   => '<span class="screen-reader-text">, </span>',
 			) );
 
@@ -42,6 +42,6 @@
 
 	<footer class="entry-footer">
 		<?php twentysixteen_entry_meta(); ?>
-		<?php edit_post_link( esc_html__( 'Edit', 'twentysixteen' ), '<span class="edit-link">', '</span>' ); ?>
+		<?php edit_post_link( __( 'Edit', 'twentysixteen' ), '<span class="edit-link">', '</span>' ); ?>
 	</footer><!-- .entry-footer -->
 </article><!-- #post-## -->

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -12,7 +12,7 @@
 	<header class="entry-header">
 		<?php
 			if ( is_sticky() && is_home() && ! is_paged() ) {
-				printf( '<span class="sticky-post">%s</span>', esc_html__( 'Featured', 'twentysixteen' ) );
+				printf( '<span class="sticky-post">%s</span>', __( 'Featured', 'twentysixteen' ) );
 			}
 
 			the_title( sprintf( '<h2 class="entry-title"><a href="%s" rel="bookmark">', esc_url( get_permalink() ) ), '</a></h2>' );
@@ -29,18 +29,18 @@
 
 	<div class="entry-content">
 		<?php
-			/* translators: %s: Name of current post */
 			the_content( sprintf(
-				wp_kses( __( 'Continue reading %s', 'twentysixteen' ), array( 'span' => array( 'class' => array() ) ) ),
+				/* translators: %s: Name of current post */
+				__( 'Continue reading %s', 'twentysixteen' ),
 				the_title( '<span class="screen-reader-text">"', '"</span>', false )
 			) );
 
 			wp_link_pages( array(
-				'before'      => '<div class="page-links"><span class="page-links-title">' . esc_html__( 'Pages:', 'twentysixteen' ) . '</span>',
+				'before'      => '<div class="page-links"><span class="page-links-title">' . __( 'Pages:', 'twentysixteen' ) . '</span>',
 				'after'       => '</div>',
 				'link_before' => '<span>',
 				'link_after'  => '</span>',
-				'pagelink'    => '<span class="screen-reader-text">' . esc_html__( 'Page', 'twentysixteen' ) . ' </span>%',
+				'pagelink'    => '<span class="screen-reader-text">' . __( 'Page', 'twentysixteen' ) . ' </span>%',
 				'separator'   => '<span class="screen-reader-text">, </span>',
 			) );
 		?>
@@ -48,6 +48,6 @@
 
 	<footer class="entry-footer">
 		<?php twentysixteen_entry_meta(); ?>
-		<?php edit_post_link( esc_html__( 'Edit', 'twentysixteen' ), '<span class="edit-link">', '</span>' ); ?>
+		<?php edit_post_link( __( 'Edit', 'twentysixteen' ), '<span class="edit-link">', '</span>' ); ?>
 	</footer><!-- .entry-footer -->
 </article><!-- #post-## -->


### PR DESCRIPTION
Twenty Sixteen currently over escapes, escaping translations & WordPress functions which may legitimately include HTML.

Similar to Twenty Fifteen in https://core.trac.wordpress.org/ticket/30724 we should remove these calls.
