### PR TITLE
Description missing for `Sidebar` #10

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -125,7 +125,7 @@ function twentysixteen_widgets_init() {
 	register_sidebar( array(
 		'name'          => esc_html__( 'Sidebar', 'twentysixteen' ),
 		'id'            => 'sidebar-1',
-		'description'   => __( 'Add widgets here to appear in your sidebar.', 'twentysixteen' ),
+		'description'   => esc_html__( 'Add widgets here to appear in your sidebar.', 'twentysixteen' ),
 		'before_widget' => '<aside id="%1$s" class="widget %2$s">',
 		'after_widget'  => '</aside>',
 		'before_title'  => '<h2 class="widget-title">',

--- a/functions.php
+++ b/functions.php
@@ -125,7 +125,7 @@ function twentysixteen_widgets_init() {
 	register_sidebar( array(
 		'name'          => esc_html__( 'Sidebar', 'twentysixteen' ),
 		'id'            => 'sidebar-1',
-		'description'   => '',
+		'description'   => __( 'Add widgets here to appear in your sidebar.', 'twentysixteen' ),
 		'before_widget' => '<aside id="%1$s" class="widget %2$s">',
 		'after_widget'  => '</aside>',
 		'before_title'  => '<h2 class="widget-title">',


### PR DESCRIPTION
The description from `sidebar-1` is missing - [issue](https://github.com/WordPress/twentysixteen/issues/10)
