### PR TITLE
Fix WordPress Coding Standards for PHP_CodeSniffer Error  in archive.php

### DIFF
--- a/CONTRIBUTERS.md
+++ b/CONTRIBUTERS.md
@@ -1,1 +1,2 @@
 @dd32
+@hideokamoto

--- a/archive.php
+++ b/archive.php
@@ -52,8 +52,8 @@ get_header(); ?>
 				) );
 			endif;
 
-		// If no content, include the "No posts found" template.
 		else :
+				// If no content, include the "No posts found" template.
 			get_template_part( 'template-parts/content', 'none' );
 
 		endif;

--- a/archive.php
+++ b/archive.php
@@ -53,7 +53,7 @@ get_header(); ?>
 			endif;
 
 		else :
-				// If no content, include the "No posts found" template.
+			// If no content, include the "No posts found" template.
 			get_template_part( 'template-parts/content', 'none' );
 
 		endif;


### PR DESCRIPTION
---

 55 | ERROR | [x] Line indented incorrectly; expected at least 3 tabs,
##     |       |     found 2 (Generic. WhiteSpace. ScopeIndent. Incorrect)
