### PR TITLE
Fix WordPress Coding Standards for PHP_CodeSniffer Error  in comment.php

### DIFF
--- a/CONTRIBUTERS.md
+++ b/CONTRIBUTERS.md
@@ -1,1 +1,2 @@
 @dd32
+@hideokamoto

--- a/comments.php
+++ b/comments.php
@@ -47,8 +47,8 @@ if ( post_password_required() ) {
 	<?php endif; // Check for have_comments(). ?>
 
 	<?php
-		// If comments are closed and there are comments, let's leave a little note, shall we?
-		if ( ! comments_open() && get_comments_number() && post_type_supports( get_post_type(), 'comments' ) ) :
+	// If comments are closed and there are comments, let's leave a little note, shall we?
+	if ( ! comments_open() && get_comments_number() && post_type_supports( get_post_type(), 'comments' ) ) :
 	?>
 		<p class="no-comments"><?php _e( 'Comments are closed.', 'twentysixteen' ); ?></p>
 	<?php endif; ?>

--- a/comments.php
+++ b/comments.php
@@ -26,7 +26,7 @@ if ( post_password_required() ) {
 		<h2 class="comments-title">
 			<?php
 				printf( _nx( 'One thought on &ldquo;%2$s&rdquo;', '%1$s thoughts on &ldquo;%2$s&rdquo;', get_comments_number(), 'comments title', 'twentysixteen' ),
-					number_format_i18n( get_comments_number() ), get_the_title() );
+				number_format_i18n( get_comments_number() ), get_the_title() );
 			?>
 		</h2>
 


### PR DESCRIPTION
## FILE: /var/www/wordpress/wp-content/themes/twentysixteen/comments.php
## FOUND 2 ERRORS AFFECTING 2 LINES

 29 | ERROR | [x] Multi-line function call not indented correctly;
    |       |     expected 16 spaces but found 20
    |       |     (PEAR.Functions.FunctionCallSignature.Indent)
 51 | ERROR | [x] Line indented incorrectly; expected 1 tabs, found 2
##     |       |     (Generic.WhiteSpace.ScopeIndent.IncorrectExact)
## PHPCBF CAN FIX THE 2 MARKED SNIFF VIOLATIONS AUTOMATICALLY
