### PR TITLE
Fix #17 - hfeed class only on pages with multiple hentry elements

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -283,6 +283,12 @@ function twentysixteen_body_classes( $classes ) {
 		$classes[] = 'no-sidebar';
 	}
 
+	// Adds a class of hfeed to pages with multiple hentry elements
+	global $wp_query;
+	if ( $wp_query->post_count > 1 ) {
+		$classes[] = 'hfeed';
+	}
+
 	return $classes;
 }
 add_filter( 'body_class', 'twentysixteen_body_classes' );

--- a/header.php
+++ b/header.php
@@ -19,7 +19,7 @@
 </head>
 
 <body <?php body_class(); ?>>
-<div id="page" class="hfeed site">
+<div id="page" class="site">
 	<div class="site-inner">
 		<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'twentysixteen' ); ?></a>
 


### PR DESCRIPTION
I figured checking the post count would be simpler than checking a series of template tags. I'm assuming it's safe to use `$wp_query` here instead of `$wp_the_query`?
