### PR TITLE
fix #17 - hfeed class only on pages with multiple hentry elements

### DIFF
--- a/CONTRIBUTERS.md
+++ b/CONTRIBUTERS.md
@@ -1,1 +1,2 @@
 @dd32
+@karpstrucking

--- a/css/editor-style.css
+++ b/css/editor-style.css
@@ -408,9 +408,15 @@ a {
  * 6.0 Galleries
  */
 
-.gallery-item {
+.gallery {
+    margin-bottom: 1.75em;
+    margin-left: -1.1666667%;
+    margin-right: -1.1666667%;
+}
+
+.gallery .gallery-item {
 	display: inline-block;
-	padding: 0 2.3333333% 2.3333333%;
+	padding: 0 1.1666667% 2.3333333%;
 	text-align: center;
 	vertical-align: top;
 	width: 100%;

--- a/css/editor-style.css
+++ b/css/editor-style.css
@@ -409,14 +409,12 @@ a {
  */
 
 .gallery {
-    margin-bottom: 1.75em;
-    margin-left: -1.1666667%;
-    margin-right: -1.1666667%;
+    margin: 0 -1.1666667% 1.75em;
 }
 
 .gallery .gallery-item {
 	display: inline-block;
-	padding: 0 1.1666667% 2.3333333%;
+	padding: 0 1.1400652% 2.2801304%;
 	text-align: center;
 	vertical-align: top;
 	width: 100%;

--- a/functions.php
+++ b/functions.php
@@ -283,6 +283,12 @@ function twentysixteen_body_classes( $classes ) {
 		$classes[] = 'no-sidebar';
 	}
 
+	// Adds a class of hfeed to pages with multiple hentry elements
+	global $wp_query;
+	if ( $wp_query->post_count > 1 ) {
+		$classes[] = 'hfeed';
+	}
+
 	return $classes;
 }
 add_filter( 'body_class', 'twentysixteen_body_classes' );

--- a/functions.php
+++ b/functions.php
@@ -284,8 +284,7 @@ function twentysixteen_body_classes( $classes ) {
 	}
 
 	// Adds a class of hfeed to pages with multiple hentry elements
-	global $wp_query;
-	if ( $wp_query->post_count > 1 ) {
+	if ( ! is_singular() ) {
 		$classes[] = 'hfeed';
 	}
 

--- a/header.php
+++ b/header.php
@@ -19,7 +19,7 @@
 </head>
 
 <body <?php body_class(); ?>>
-<div id="page" class="hfeed site">
+<div id="page" class="site">
 	<div class="site-inner">
 		<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'twentysixteen' ); ?></a>
 


### PR DESCRIPTION
I figured checking the post count would be simpler than checking a series of template tags. I'm assuming it's safe to use `$wp_query` here instead of `$wp_the_query`?
