### PR TITLE
Use :first-of-type to style top post

### DIFF
--- a/CONTRIBUTERS.md
+++ b/CONTRIBUTERS.md
@@ -1,1 +1,2 @@
 @dd32
+@Chrisdc1

--- a/style.css
+++ b/style.css
@@ -1940,7 +1940,7 @@ a.post-thumbnail:focus {
 
 body:not(.error404):not(.search-no-results) .page-header {
 	border-top: 4px solid #1a1a1a;
-	padding-top: 1.75em;
+	padding: 1.75em 0 3.5em;
 }
 
 .page-title {

--- a/style.css
+++ b/style.css
@@ -1546,7 +1546,7 @@ article[class^="post-"] {
 	position: relative;
 }
 
-.site-main > article[class^="post-"]:first-child {
+.site-main > article[class^="post-"]:first-of-type {
 	padding-top: 0;
 }
 


### PR DESCRIPTION
At the moment each blog post has a top padding, which is removed on the top post with a :first-child rule. This is fine unless you set your front page to be a static page, in which there will be an (invisible) heading above the first post, and the :first-child rule no longer applies.

![padding](https://cloud.githubusercontent.com/assets/4218735/9564768/fcbed58c-4ea7-11e5-8e5e-97f471d8d9e2.jpg)

This pull request switches the :first-child rule to :first-of-type
