### PR TITLE
Modify some IF statements syntax to fit WordPress PHP Coding Standards

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,3 +3,4 @@
 @grapplerulrich
 @davidakennedy
 @frank-klein
+@ihorvorotnov

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,2 +1,3 @@
 @dd32
 @mor10
+@ihorvorotnov

--- a/archive.php
+++ b/archive.php
@@ -43,14 +43,14 @@ get_header(); ?>
 
 			endwhile;
 
-			if ( have_posts() ) :
+			if ( have_posts() ) {
 				// Previous/next page navigation.
 				the_posts_pagination( array(
 					'prev_text'          => esc_html__( 'Previous page', 'twentysixteen' ),
 					'next_text'          => esc_html__( 'Next page', 'twentysixteen' ),
 					'before_page_number' => '<span class="meta-nav screen-reader-text">' . esc_html__( 'Page', 'twentysixteen' ) . ' </span>',
 				) );
-			endif;
+			}
 
 		// If no content, include the "No posts found" template.
 		else :

--- a/css/editor-style.css
+++ b/css/editor-style.css
@@ -24,7 +24,7 @@ Description: Used to style the TinyMCE editor.
  */
 body {
 	color: #1a1a1a;
-	font-family: Merriweather, serif;
+	font-family: Merriweather, Georgia, serif;
 	font-size: 16px;
 	font-weight: 400;
 	line-height: 1.75;

--- a/image.php
+++ b/image.php
@@ -87,9 +87,9 @@ get_header(); ?>
 
 				<?php
 					// If comments are open or we have at least one comment, load up the comment template
-					if ( comments_open() || get_comments_number() ) :
+					if ( comments_open() || get_comments_number() ) {
 						comments_template();
-					endif;
+					}
 
 					// Parent post navigation
 					the_post_navigation( array(

--- a/inc/custom-header.php
+++ b/inc/custom-header.php
@@ -68,11 +68,11 @@ if ( ! function_exists( 'twentysixteen_header_style' ) ) :
  */
 function twentysixteen_header_style() {
 	// If the header text option is untouched, let's bail.
-	if ( display_header_text() ) {
+	if ( display_header_text() ) :
 		return;
 
 	// If the header text has been hidden.
-	} else {
+	else :
 	?>
 		<style type="text/css" id="twentysixteen-header-css">
 			.site-branding {
@@ -86,6 +86,6 @@ function twentysixteen_header_style() {
 			}
 		</style>
 	<?php
-	}
+	endif;
 }
 endif; // twentysixteen_header_style

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -23,13 +23,13 @@ function twentysixteen_comment_nav() {
 		<h2 class="screen-reader-text"><?php _e( 'Comment navigation', 'twentysixteen' ); ?></h2>
 		<div class="nav-links">
 			<?php
-				if ( $prev_link = get_previous_comments_link( esc_html__( 'Older Comments', 'twentysixteen' ) ) ) :
+				if ( $prev_link = get_previous_comments_link( esc_html__( 'Older Comments', 'twentysixteen' ) ) ) {
 					printf( '<div class="nav-previous">%s</div>', $prev_link );
-				endif;
+				}
 
-				if ( $next_link = get_next_comments_link( esc_html__( 'Newer Comments', 'twentysixteen' ) ) ) :
+				if ( $next_link = get_next_comments_link( esc_html__( 'Newer Comments', 'twentysixteen' ) ) ) {
 					printf( '<div class="nav-next">%s</div>', $next_link );
-				endif;
+				}
 			?>
 		</div><!-- .nav-links -->
 	</nav><!-- .comment-navigation -->

--- a/page.php
+++ b/page.php
@@ -25,9 +25,9 @@ get_header(); ?>
 				get_template_part( 'template-parts/content', 'page' );
 
 				// If comments are open or we have at least one comment, load up the comment template.
-				if ( comments_open() || get_comments_number() ) :
+				if ( comments_open() || get_comments_number() ) {
 					comments_template();
-				endif;
+				}
 
 			// End of the loop.
 			endwhile;

--- a/single.php
+++ b/single.php
@@ -19,9 +19,9 @@ get_header(); ?>
 			get_template_part( 'template-parts/content', 'single' );
 
 			// If comments are open or we have at least one comment, load up the comment template.
-			if ( comments_open() || get_comments_number() ) :
+			if ( comments_open() || get_comments_number() ) {
 				comments_template();
-			endif;
+			}
 
 			// Previous/next post navigation.
 			the_post_navigation( array(

--- a/style.css
+++ b/style.css
@@ -315,7 +315,7 @@ input,
 select,
 textarea {
 	color: #1a1a1a;
-	font-family: Merriweather, serif;
+	font-family: Merriweather, Georgia, serif;
 	font-size: 16px;
 	font-size: 1rem;
 	line-height: 1.75;
@@ -560,24 +560,24 @@ td {
 /* Placeholder text color -- selectors need to be separate to work. */
 ::-webkit-input-placeholder {
 	color: #757575;
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 }
 
 :-moz-placeholder {
 	color: #757575;
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 }
 
 ::-moz-placeholder {
 	color: #757575;
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 	opacity: 1;
 	/* Since FF19 lowers the opacity of the placeholder by default */
 }
 
 :-ms-input-placeholder {
 	color: #757575;
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 }
 
 
@@ -601,7 +601,7 @@ input[type="submit"][disabled]:focus {
 	border-radius: 2px;
 	background: #007acc;
 	color: #fff;
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 	font-weight: 700;
 	line-height: 1;
 	padding: 0.75em 0.875em 0.625em;
@@ -654,7 +654,7 @@ textarea:focus {
 
 .post-password-form label {
 	color: #757575;
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 	font-size: 13px;
 	font-size: 0.8125rem;
 	line-height: 1.6153846154;
@@ -759,7 +759,7 @@ a:active {
 }
 
 .main-navigation {
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 }
 
 .site-footer .main-navigation {
@@ -1014,7 +1014,7 @@ a:active {
 	border-top: 4px solid #1a1a1a;
 	border-bottom: 4px solid #1a1a1a;
 	clear: both;
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 	margin: 0 7.6923% 3.5em;
 }
 
@@ -1039,7 +1039,7 @@ a:active {
 
 .post-navigation .post-title {
 	display: inline;
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 	font-size: 23px;
 	font-size: 1.4375rem;
 	-webkit-font-variant-ligatures: common-ligatures;
@@ -1060,7 +1060,7 @@ a:active {
 
 .pagination {
 	border-top: 4px solid #1a1a1a;
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 	font-size: 19px;
 	font-size: 1.1875rem;
 	margin: 0 7.6923% 2.947368421em;
@@ -1165,7 +1165,7 @@ a:active {
 	color: #757575;
 	font-size: 13px;
 	font-size: 0.8125rem;
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 	line-height: 1.6153846154;
 	margin: 0 7.6923% 2.1538461538em;
 	padding: 1.0769230769em 0;
@@ -1212,7 +1212,7 @@ a:active {
 	box-shadow: 0 0 1px 1px rgba(0, 0, 0, 0.2);
 	color: #21759b;
 	display: block;
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 	font-size: 14px;
 	font-weight: 700;
 	left: -9999em;
@@ -1336,7 +1336,7 @@ article[class^="post-"]:after,
 }
 
 .widget .widget-title {
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 	font-size: 16px;
 	font-size: 1rem;
 	line-height: 1.3125;
@@ -1386,7 +1386,7 @@ article[class^="post-"]:after,
 .widget_recent_entries .post-date {
 	color: #757575;
 	display: block;
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 }
 
 /* RSS widget */
@@ -1403,7 +1403,7 @@ article[class^="post-"]:after,
 	color: #757575;
 	font-size: 13px;
 	font-size: 0.8125rem;
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 	font-style: normal;
 	display: block;
 	line-height: 2.1538461538;
@@ -1414,7 +1414,7 @@ article[class^="post-"]:after,
 	border: 1px solid #e8e8e8;
 	border-radius: 2px;
 	display: inline-block;
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 	font-size: inherit !important;
 	line-height: 1;
 	margin: 0 0.1875em 0.4375em 0 !important;
@@ -1468,7 +1468,7 @@ article[class^="post-"]:after,
 }
 
 .site-title {
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 	font-size: 23px;
 	font-size: 1.4375rem;
 	font-weight: 700;
@@ -1560,7 +1560,7 @@ article[class^="post-"] {
 }
 
 .entry-title {
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 	font-size: 28px;
 	font-size: 1.75rem;
 	font-weight: 700;
@@ -1879,7 +1879,7 @@ a.post-thumbnail:focus {
 
 .entry-footer {
 	color: #757575;
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 	font-size: 13px;
 	font-size: 0.8125rem;
 	line-height: 1.6153846154;
@@ -1915,7 +1915,7 @@ a.post-thumbnail:focus {
 .sticky-post {
 	color: #757575;
 	display: block;
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 	font-size: 13px;
 	font-size: 0.8125rem;
 	line-height: 1.6153846154;
@@ -1944,7 +1944,7 @@ body:not(.error404):not(.search-no-results) .page-header {
 }
 
 .page-title {
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 	font-size: 23px;
 	font-size: 1.4375rem;
 	line-height: 1.2173913043;
@@ -1971,7 +1971,7 @@ body:not(.error404):not(.search-no-results) .page-header {
 
 .page-links {
 	clear: both;
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 	margin: 0 0 1.75em;
 }
 
@@ -2079,7 +2079,7 @@ body:not(.error404):not(.search-no-results) .page-header {
 .comments-title,
 .comment-reply-title {
 	border-top: 4px solid #1a1a1a;
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 	font-size: 23px;
 	font-size: 1.4375rem;
 	font-weight: 700;
@@ -2135,7 +2135,7 @@ body:not(.error404):not(.search-no-results) .page-header {
 .comment-metadata,
 .pingback .edit-link {
 	color: #757575;
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 	font-size: 13px;
 	font-size: 0.8125rem;
 	line-height: 1.6153846154;
@@ -2185,7 +2185,7 @@ body:not(.error404):not(.search-no-results) .page-header {
 	border-radius: 2px;
 	color: #007acc;
 	display: inline-block;
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 	font-size: 13px;
 	font-size: 0.8125rem;
 	line-height: 1;
@@ -2206,7 +2206,7 @@ body:not(.error404):not(.search-no-results) .page-header {
 
 .comment-form label {
 	color: #757575;
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 	font-size: 13px;
 	font-size: 0.8125rem;
 	display: block;
@@ -2232,7 +2232,7 @@ body:not(.error404):not(.search-no-results) .page-header {
 
 .no-comments {
 	border-top: 1px solid #e8e8e8;
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 	font-weight: 700;
 	margin: 0;
 	padding-top: 1.75em;
@@ -2317,7 +2317,7 @@ body:not(.error404):not(.search-no-results) .page-header {
 .site-footer .site-title:after {
 	content: "\002f";
 	display: inline-block;
-	font-family: Montserrat;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 	opacity: 0.7;
 	padding: 0 0.307692308em 0 0.538461538em;
 }
@@ -2531,7 +2531,7 @@ p > video {
 .widecolumn label,
 .widecolumn .mu_register label {
 	color: #757575;
-	font-family: Montserrat, sans-serif;
+	font-family: Montserrat, "Helvetica Neue", sans-serif;
 	font-size: 13px;
 	font-size: 0.8125rem;
 	font-weight: 400;

--- a/template-parts/content-single.php
+++ b/template-parts/content-single.php
@@ -13,11 +13,11 @@
 		<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
 	</header><!-- .entry-header -->
 
-	<?php if ( has_excerpt() ) { ?>
+	<?php if ( has_excerpt() ) : ?>
 		<div class="entry-intro">
 			<?php the_excerpt(); ?>
 		</div><!-- .entry-intro -->
-	<?php } ?>
+	<?php endif; ?>
 
 	<?php twentysixteen_post_thumbnail(); ?>
 
@@ -34,9 +34,9 @@
 				'separator'   => '<span class="screen-reader-text">, </span>',
 			) );
 
-			if ( '' != get_the_author_meta( 'description' ) ) :
+			if ( '' != get_the_author_meta( 'description' ) ) {
 				get_template_part( 'template-parts/biography' );
-			endif;
+			}
 		?>
 	</div><!-- .entry-content -->
 

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -19,11 +19,11 @@
 		?>
 	</header><!-- .entry-header -->
 
-	<?php if ( has_excerpt() ) { ?>
+	<?php if ( has_excerpt() ) : ?>
 		<div class="entry-intro">
 			<?php the_excerpt(); ?>
 		</div><!-- .entry-intro -->
-	<?php } ?>
+	<?php endif; ?>
 
 	<?php twentysixteen_post_thumbnail(); ?>
 


### PR DESCRIPTION
After studying the code I've spotted some incorrect usage of standard (curly braces) and alternative syntax for IF statements. As per WordPress PHP Coding Standards, alternative syntax should be used for complex chunks of code, mostly in templates where we mix PHP and HTML. For other cases, especially one-liners, curly braces should be used. 

Or, at the very least, we should have a system. If we obey to use alternative syntax when mixing PHP and HTML, let's do it everywhere (see changes in `template-parts/content-single.php` and `template-parts/content.php`). And for one-liners it's better to have braces (see changes in `inc/template-tags.php` for example).

Check WordPress PHP Coding Standards [here](https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#brace-style).
