### PR TITLE
Use custom class in place of article[class^=post-]

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -5,6 +5,7 @@
 @grapplerulrich
 @davidakennedy
 @frank-klein
+@peterwilsoncc
 @tywayne
 @wenthemes
 @monika

--- a/functions.php
+++ b/functions.php
@@ -296,6 +296,21 @@ function twentysixteen_body_classes( $classes ) {
 add_filter( 'body_class', 'twentysixteen_body_classes' );
 
 /**
+ * Adds custom classes to the array of post classes.
+ *
+ * @param array $classes Classes for the post element.
+ * @return array
+ */
+function twentysixteen_post_classes( $classes ) {
+
+	// Single selector for all content types
+	$classes[] = 'entry';
+
+	return $classes;
+}
+add_filter( 'post_class', 'twentysixteen_post_classes' );
+
+/**
  * Convert HEX to RGB.
  *
  * @since Twenty Sixteen 1.0

--- a/style.css
+++ b/style.css
@@ -1319,8 +1319,8 @@ blockquote.aligncenter {
 .site-content:after,
 .site-footer:before,
 .site-footer:after,
-article[class^="post-"]:before,
-article[class^="post-"]:after,
+article.entry:before,
+article.entry:after,
 .primary-menu:before,
 .primary-menu:after,
 .social-links-menu:before,
@@ -1339,7 +1339,7 @@ article[class^="post-"]:after,
 .comment-content:after,
 .site-content:after,
 .site-footer:after,
-article[class^="post-"]:after,
+article.entry:after,
 .primary-menu:after,
 .social-links-menu:after,
 .textwidget:after,
@@ -1582,12 +1582,12 @@ article[class^="post-"]:after,
  * 11.2 - Posts and pages
  */
 
-article[class^="post-"] {
+article.entry {
 	padding-bottom: 3.5em;
 	position: relative;
 }
 
-article[class^="post-"] + article[class^="post-"] {
+article.entry + article.entry {
 	padding-top: 3.5em;
 }
 


### PR DESCRIPTION
There is no reliable way to ensure the selector `article[class^="post-"]` will be valid after filters are applied by plugins and child themes. It could be invalidated by a filter such as:

``` php
function plugin_post_class( $classes ) {
  $plugin_classes = array( 'plugin', 'classes' );
  return array_merge( $plugin_classes, $classes );
}
```

Assigning an additional class via a filter will avoid this.  
