### PR TITLE
Only display author bio on multi-author sites

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,2 +1,3 @@
 @dd32
 @mor10
+@jeherve

--- a/template-parts/content-single.php
+++ b/template-parts/content-single.php
@@ -34,7 +34,7 @@
 				'separator'   => '<span class="screen-reader-text">, </span>',
 			) );
 
-			if ( '' != get_the_author_meta( 'description' ) ) :
+			if ( '' != get_the_author_meta( 'description' ) && is_multi_author() ) :
 				get_template_part( 'template-parts/biography' );
 			endif;
 		?>


### PR DESCRIPTION
A post's single view includes the author's avatar and a link to their author archive page. This information is displayed right after the content, in the `entry-footer` container.

If you've filled in the biography section in your Profile page, a small biography will be added right above that `entry-footer` container, at the end of the content.

While the 2 containers are not displayed below each other on desktop (the `entry-footer` container appears in the sidebar), it feels overkill to display author information twice, especially on personal sites where we only have a single author.

I suggest we only display the biography on sites with multiple published authors, like we do in Twenty Eleven ([ref](https://github.com/WordPress/WordPress/blob/master/wp-content/themes/twentyeleven/content-single.php#L54)).
