### PR TITLE
Add author's archive page link to avatar.

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,2 +1,3 @@
 @dd32
 @mor10
+@jeherve

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -49,7 +49,7 @@ if ( ! function_exists( 'twentysixteen_entry_meta' ) ) :
 function twentysixteen_entry_meta() {
 	if ( 'post' == get_post_type() ) {
 		$author_avatar_size = apply_filters( 'twentysixteen_author_avatar_size', 49 );
-		printf( '<span class="byline"><span class="author vcard">%1$s<span class="screen-reader-text">%2$s </span> <a class="url fn n" href="%3$s">%4$s</a></span></span>',
+		printf( '<span class="byline"><span class="author vcard"><a class="url fn n" href="%3$s">%1$s</a><span class="screen-reader-text">%2$s </span> <a class="url fn n" href="%3$s">%4$s</a></span></span>',
 			get_avatar( get_the_author_meta( 'user_email' ), $author_avatar_size ),
 			esc_html_x( 'Author', 'Used before post author name.', 'twentysixteen' ),
 			esc_url( get_author_posts_url( get_the_author_meta( 'ID' ) ) ),


### PR DESCRIPTION
One of my first instincts as a reader was to click on the author's image to find out more about them. I think there should be a link to their archive page there as well, and not just on their name displayed below the image.
