### PR TITLE
Correct comment above register_nav_menus

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,3 +3,4 @@
 @grapplerulrich
 @davidakennedy
 @frank-klein
+@tywayne

--- a/functions.php
+++ b/functions.php
@@ -68,7 +68,7 @@ function twentysixteen_setup() {
 	add_theme_support( 'post-thumbnails' );
 	set_post_thumbnail_size( 1200, 0, true );
 
-	// This theme uses wp_nav_menu() in one location.
+	// This theme uses wp_nav_menu() in two locations.
 	register_nav_menus( array(
 		'primary' => esc_html__( 'Primary Menu', 'twentysixteen' ),
 		'social'  => esc_html__( 'Social Links Menu', 'twentysixteen' ),


### PR DESCRIPTION
Fixes incorrect comment for `register_nav_menus` in functions.php. Fixes Issue #67 
