### PR TITLE
Javascript failsafes

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,3 +3,4 @@
 @grapplerulrich
 @davidakennedy
 @frank-klein
+@peterwilsoncc

--- a/functions.php
+++ b/functions.php
@@ -201,7 +201,7 @@ endif;
  * @since Twenty Sixteen 1.0
  */
 function twentysixteen_javascript_detection() {
-	echo "<script>(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);</script>\n";
+	echo "<script>(function(html){html.className = html.className.replace(/\bno-js\b/,'') + ' js'})(document.documentElement);</script>\n";
 }
 add_action( 'wp_head', 'twentysixteen_javascript_detection', 0 );
 

--- a/functions.php
+++ b/functions.php
@@ -245,6 +245,13 @@ function twentysixteen_scripts() {
 		'expand'   => '<span class="screen-reader-text">' . esc_html__( 'expand child menu', 'twentysixteen' ) . '</span>',
 		'collapse' => '<span class="screen-reader-text">' . esc_html__( 'collapse child menu', 'twentysixteen' ) . '</span>',
 	) );
+
+	// configure twentysixteen JavaScript
+	wp_localize_script( 'twentysixteen-script', 'twentysixteenSettings', array(
+		// bypass the bigImageClass on some pages: "true" and "false" passed as strings 
+		// to ensure the data is consistant.
+		'bypassBigImageClass' => ( is_page() || is_search() || is_attachment() || is_404() ) ? "true" : "false",
+	) );
 }
 add_action( 'wp_enqueue_scripts', 'twentysixteen_scripts' );
 

--- a/js/functions.js
+++ b/js/functions.js
@@ -103,7 +103,9 @@
 
 	// Add a class to big image and caption larger than or equal to 840px.
 	function bigImageClass() {
-		if ( $body.hasClass( 'page' ) || $body.hasClass( 'search' ) || $body.hasClass( 'single-attachment' ) || $body.hasClass( 'error404' ) ) {
+		// check settings for bypassing the big image class. The bypass setting is set as
+		// a string. Do not change this to a boolean.
+		if ( "true" === twentysixteenSettings.bypassBigImageClass ) {
 			return;
 		}
 


### PR DESCRIPTION
A couple of JavaScript failsafes:
- `body_class` is filterable & easily removed - presence of particular classes can not be guaranteed to match the results of WordPress conditionals. Use conditionals and pass settings to the JavaScript.
- Presence of `html.no-js` can't be guaranteed in a child theme - an author unfamiliar with the convention could think it means don't use JavaScript - so add the`js` class independently of `no-js`.
