### PR TITLE
Add post title to edit_post_link for improved accessibility

### DIFF
--- a/image.php
+++ b/image.php
@@ -81,7 +81,17 @@ get_header(); ?>
 								);
 							}
 						?>
-						<?php edit_post_link( esc_html__( 'Edit', 'twentysixteen' ), '<span class="edit-link">', '</span>' ); ?>
+						<?php
+							edit_post_link(
+								sprintf(
+									/* translators: %s: Name of current post */
+									esc_html__( 'Edit %s', 'twentysixteen' ),
+									the_title( '<span class="screen-reader-text">', '</span>', false )
+								),
+								'<span class="edit-link">',
+								'</span>'
+							);
+						?>
 					</footer><!-- .entry-footer -->
 				</article><!-- #post-## -->
 

--- a/template-parts/content-page.php
+++ b/template-parts/content-page.php
@@ -30,6 +30,16 @@
 		?>
 	</div><!-- .entry-content -->
 
-	<?php edit_post_link( esc_html__( 'Edit', 'twentysixteen' ), '<footer class="entry-footer"><span class="edit-link">', '</span></footer><!-- .entry-footer -->' ); ?>
+	<?php
+		edit_post_link(
+			sprintf(
+				/* translators: %s: Name of current post */
+				esc_html__( 'Edit %s', 'twentysixteen' ),
+				the_title( '<span class="screen-reader-text">', '</span>', false )
+			),
+			'<footer class="entry-footer"><span class="edit-link">',
+			'</span></footer><!-- .entry-footer -->'
+		);
+	?>
 
 </article><!-- #post-## -->

--- a/template-parts/content-search.php
+++ b/template-parts/content-search.php
@@ -25,12 +25,32 @@
 
 		<footer class="entry-footer">
 			<?php twentysixteen_entry_meta(); ?>
-			<?php edit_post_link( esc_html__( 'Edit', 'twentysixteen' ), '<span class="edit-link">', '</span>' ); ?>
+			<?php
+				edit_post_link(
+					sprintf(
+						/* translators: %s: Name of current post */
+						esc_html__( 'Edit %s', 'twentysixteen' ),
+						the_title( '<span class="screen-reader-text">"', '"</span>', false )
+					),
+					'<span class="edit-link">',
+					'</span>'
+				);
+			?>
 		</footer><!-- .entry-footer -->
 
 	<?php else : ?>
 
-		<?php edit_post_link( esc_html__( 'Edit', 'twentysixteen' ), '<footer class="entry-footer"><span class="edit-link">', '</span></footer><!-- .entry-footer -->' ); ?>
+		<?php
+			edit_post_link(
+				sprintf(
+					/* translators: %s: Name of current post */
+					esc_html__( 'Edit %s', 'twentysixteen' ),
+					the_title( '<span class="screen-reader-text">', '</span>', false )
+				),
+				'<footer class="entry-footer"><span class="edit-link">',
+				'</span></footer><!-- .entry-footer -->'
+			);
+		?>
 
 	<?php endif; ?>
 </article><!-- #post-## -->

--- a/template-parts/content-single.php
+++ b/template-parts/content-single.php
@@ -42,6 +42,16 @@
 
 	<footer class="entry-footer">
 		<?php twentysixteen_entry_meta(); ?>
-		<?php edit_post_link( esc_html__( 'Edit', 'twentysixteen' ), '<span class="edit-link">', '</span>' ); ?>
+		<?php
+			edit_post_link(
+				sprintf(
+					/* translators: %s: Name of current post */
+					esc_html__( 'Edit %s', 'twentysixteen' ),
+					the_title( '<span class="screen-reader-text">', '</span>', false )
+				),
+				'<span class="edit-link">',
+				'</span>'
+			);
+		?>
 	</footer><!-- .entry-footer -->
 </article><!-- #post-## -->

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -48,6 +48,16 @@
 
 	<footer class="entry-footer">
 		<?php twentysixteen_entry_meta(); ?>
-		<?php edit_post_link( esc_html__( 'Edit', 'twentysixteen' ), '<span class="edit-link">', '</span>' ); ?>
+		<?php
+			edit_post_link(
+				sprintf(
+					/* translators: %s: Name of current post */
+					esc_html__( 'Edit %s', 'twentysixteen' ),
+					the_title( '<span class="screen-reader-text">', '</span>', false )
+				),
+				'<span class="edit-link">',
+				'</span>'
+			);
+		?>
 	</footer><!-- .entry-footer -->
 </article><!-- #post-## -->


### PR DESCRIPTION
- Hides title with `screen-reader-text`.
- Not escaping on `the_title();` it's trusted data.

Resolves #82
