### PR TITLE
remove unnecessary value passed to get_categories() in twentysixteen_categorized_blog(). Fixes #92

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -201,7 +201,6 @@ function twentysixteen_categorized_blog() {
 		// Create an array of all the categories that are attached to posts.
 		$all_the_cool_cats = get_categories( array(
 			'fields'     => 'ids',
-			'hide_empty' => 1,
 
 			// We only need to know if there is more than one category.
 			'number'     => 2,


### PR DESCRIPTION
In template-tags.php, the function twentysixteen_categorized_blog() uses get_categories() and passes an array of args. One of these values is 'hide_empty' => 1, however, the default value for hide_empty is 1, thus is unnecessary.

This removes the unnecessary value from the array and fixes #92 
