### PR TITLE
Border on Menus with Submenus enhancement

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,3 +3,4 @@
 @grapplerulrich
 @davidakennedy
 @frank-klein
+@nhuja

--- a/style.css
+++ b/style.css
@@ -816,7 +816,9 @@ a:active {
 
 .dropdown-toggle {
 	background-color: #fff;
-	border: 1px solid #e8e8e8;
+	border: none;
+	border-top: 1px solid #e8e8e8;
+	border-bottom: 1px solid #e8e8e8;
 	border-radius: 0;
 	color: #1a1a1a;
 	content: "";
@@ -842,7 +844,7 @@ a:active {
 .dropdown-toggle:hover,
 .dropdown-toggle:focus {
 	background-color: #fff;
-	border-color: #007acc;
+	border: 1px solid #007acc;
 	color: #007acc;
 	z-index: 1;
 }


### PR DESCRIPTION
Replacing the boxy sub menu indication to be more aligned with the other menu items (without submenus). Removed the side borders, appears same on hover.

Fixes https://github.com/WordPress/twentysixteen/issues/99
