### PR TITLE
Fixed color scheme contrast ratios 

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -3,3 +3,4 @@
 @grapplerulrich
 @davidakennedy
 @frank-klein
+@ohryan

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -151,7 +151,7 @@ function twentysixteen_get_color_schemes() {
 			'colors' => array(
 				'#3b3721',
 				'#ffef8e',
-				'#7f7d6f',
+				'#605f54',
 				'#3b3721',
 				'#774e24',
 			),

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -140,8 +140,8 @@ function twentysixteen_get_color_schemes() {
 			'label'  => esc_html__( 'Green', 'twentysixteen' ),
 			'colors' => array(
 				'#ffffff',
-				'#acc1a2',
-				'#6d8c87',
+				'#596353',
+				'#f9f3c2',
 				'#ffffff',
 				'#efeef4',
 			),

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -131,7 +131,7 @@ function twentysixteen_get_color_schemes() {
 			'colors' => array(
 				'#616a73',
 				'#4d545c',
-				'#aaaaaa',
+				'#cacaca',
 				'#ededed',
 				'#ededed',
 			),


### PR DESCRIPTION
As per WCAG, the yellow, grey and green colour schemes had contrast ratio issues. Yellow and grey were pretty minor. Green was a lot further off.
