### PR TITLE
Modify some IF statements syntax to meet WordPress Coding Standards

### DIFF
--- a/archive.php
+++ b/archive.php
@@ -43,14 +43,14 @@ get_header(); ?>
 
 			endwhile;
 
-			if ( have_posts() ) {
+			if ( have_posts() ) :
 				// Previous/next page navigation.
 				the_posts_pagination( array(
 					'prev_text'          => esc_html__( 'Previous page', 'twentysixteen' ),
 					'next_text'          => esc_html__( 'Next page', 'twentysixteen' ),
 					'before_page_number' => '<span class="meta-nav screen-reader-text">' . esc_html__( 'Page', 'twentysixteen' ) . ' </span>',
 				) );
-			}
+			endif;
 
 		// If no content, include the "No posts found" template.
 		else :

--- a/archive.php
+++ b/archive.php
@@ -41,16 +41,15 @@ get_header(); ?>
 				 */
 				get_template_part( 'template-parts/content', get_post_format() );
 
+			// End the loop.
 			endwhile;
 
-			if ( have_posts() ) :
-				// Previous/next page navigation.
-				the_posts_pagination( array(
-					'prev_text'          => esc_html__( 'Previous page', 'twentysixteen' ),
-					'next_text'          => esc_html__( 'Next page', 'twentysixteen' ),
-					'before_page_number' => '<span class="meta-nav screen-reader-text">' . esc_html__( 'Page', 'twentysixteen' ) . ' </span>',
-				) );
-			endif;
+			// Previous/next page navigation.
+			the_posts_pagination( array(
+				'prev_text'          => esc_html__( 'Previous page', 'twentysixteen' ),
+				'next_text'          => esc_html__( 'Next page', 'twentysixteen' ),
+				'before_page_number' => '<span class="meta-nav screen-reader-text">' . esc_html__( 'Page', 'twentysixteen' ) . ' </span>',
+			) );
 
 		// If no content, include the "No posts found" template.
 		else :

--- a/archive.php
+++ b/archive.php
@@ -43,14 +43,14 @@ get_header(); ?>
 
 			endwhile;
 
-			if ( have_posts() ) :
+			if ( have_posts() ) {
 				// Previous/next page navigation.
 				the_posts_pagination( array(
 					'prev_text'          => esc_html__( 'Previous page', 'twentysixteen' ),
 					'next_text'          => esc_html__( 'Next page', 'twentysixteen' ),
 					'before_page_number' => '<span class="meta-nav screen-reader-text">' . esc_html__( 'Page', 'twentysixteen' ) . ' </span>',
 				) );
-			endif;
+			}
 
 		// If no content, include the "No posts found" template.
 		else :

--- a/image.php
+++ b/image.php
@@ -97,9 +97,9 @@ get_header(); ?>
 
 				<?php
 					// If comments are open or we have at least one comment, load up the comment template
-					if ( comments_open() || get_comments_number() ) :
+					if ( comments_open() || get_comments_number() ) {
 						comments_template();
-					endif;
+					}
 
 					// Parent post navigation
 					the_post_navigation( array(

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -23,13 +23,13 @@ function twentysixteen_comment_nav() {
 		<h2 class="screen-reader-text"><?php _e( 'Comment navigation', 'twentysixteen' ); ?></h2>
 		<div class="nav-links">
 			<?php
-				if ( $prev_link = get_previous_comments_link( esc_html__( 'Older Comments', 'twentysixteen' ) ) ) :
+				if ( $prev_link = get_previous_comments_link( esc_html__( 'Older Comments', 'twentysixteen' ) ) ) {
 					printf( '<div class="nav-previous">%s</div>', $prev_link );
-				endif;
+				}
 
-				if ( $next_link = get_next_comments_link( esc_html__( 'Newer Comments', 'twentysixteen' ) ) ) :
+				if ( $next_link = get_next_comments_link( esc_html__( 'Newer Comments', 'twentysixteen' ) ) ) {
 					printf( '<div class="nav-next">%s</div>', $next_link );
-				endif;
+				}
 			?>
 		</div><!-- .nav-links -->
 	</nav><!-- .comment-navigation -->

--- a/page.php
+++ b/page.php
@@ -25,9 +25,9 @@ get_header(); ?>
 				get_template_part( 'template-parts/content', 'page' );
 
 				// If comments are open or we have at least one comment, load up the comment template.
-				if ( comments_open() || get_comments_number() ) :
+				if ( comments_open() || get_comments_number() ) {
 					comments_template();
-				endif;
+				}
 
 			// End of the loop.
 			endwhile;

--- a/sidebar-content-bottom.php
+++ b/sidebar-content-bottom.php
@@ -9,8 +9,9 @@
 ?>
 
 <?php
-if ( ! is_active_sidebar( 'sidebar-2' ) && ! is_active_sidebar( 'sidebar-3' ) )
+if ( ! is_active_sidebar( 'sidebar-2' ) && ! is_active_sidebar( 'sidebar-3' ) ) {
 	return;
+}
 
 // If we get this far, we have widgets. Let do this.
 ?>

--- a/single.php
+++ b/single.php
@@ -19,9 +19,9 @@ get_header(); ?>
 			get_template_part( 'template-parts/content', 'single' );
 
 			// If comments are open or we have at least one comment, load up the comment template.
-			if ( comments_open() || get_comments_number() ) :
+			if ( comments_open() || get_comments_number() ) {
 				comments_template();
-			endif;
+			}
 
 			// Previous/next post navigation.
 			the_post_navigation( array(

--- a/template-parts/content-single.php
+++ b/template-parts/content-single.php
@@ -13,11 +13,11 @@
 		<?php the_title( '<h1 class="entry-title">', '</h1>' ); ?>
 	</header><!-- .entry-header -->
 
-	<?php if ( has_excerpt() ) { ?>
+	<?php if ( has_excerpt() ) : ?>
 		<div class="entry-summary">
 			<?php the_excerpt(); ?>
 		</div><!-- .entry-summary -->
-	<?php } ?>
+	<?php endif; ?>
 
 	<?php twentysixteen_post_thumbnail(); ?>
 
@@ -34,9 +34,9 @@
 				'separator'   => '<span class="screen-reader-text">, </span>',
 			) );
 
-			if ( '' != get_the_author_meta( 'description' ) ) :
+			if ( '' != get_the_author_meta( 'description' ) ) {
 				get_template_part( 'template-parts/biography' );
-			endif;
+			}
 		?>
 	</div><!-- .entry-content -->
 

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -19,11 +19,11 @@
 		?>
 	</header><!-- .entry-header -->
 
-	<?php if ( has_excerpt() ) { ?>
+	<?php if ( has_excerpt() ) : ?>
 		<div class="entry-summary">
 			<?php the_excerpt(); ?>
 		</div><!-- .entry-summary -->
-	<?php } ?>
+	<?php endif; ?>
 
 	<?php twentysixteen_post_thumbnail(); ?>
 


### PR DESCRIPTION
**Fixed and updated, replacing messed  and closed #51.**

> After studying the code I've spotted some incorrect usage of standard (curly braces) and alternative syntax for IF statements. As per WordPress PHP Coding Standards, alternative syntax should be used for complex chunks of code, mostly in templates where we mix PHP and HTML. For other cases, especially one-liners, curly braces should be used.
> 
> Or, at the very least, we should have a system. If we obey to use alternative syntax when mixing PHP and HTML, let's do it everywhere (see changes in template-parts/content-single.php and template-parts/content.php). And for one-liners it's better to have braces (see changes in inc/template-tags.php for example).
> 
> Check WordPress PHP Coding Standards here.
