### PR TITLE
Use tabs instead of spaces on multi-line var declarations.

### DIFF
--- a/js/customize-preview.js
+++ b/js/customize-preview.js
@@ -4,7 +4,7 @@
 
 ( function( $ ) {
 	var $style = $( '#twentysixteen-color-scheme-css' ),
-	    api = wp.customize;
+		api = wp.customize;
 
 	if ( ! $style.length ) {
 		$style = $( 'head' ).append( '<style type="text/css" id="twentysixteen-color-scheme-css" />' )

--- a/js/functions.js
+++ b/js/functions.js
@@ -110,13 +110,13 @@
 		var entryContent = $( '.entry-content' );
 		entryContent.find( 'img.size-full' ).each( function() {
 			var img                  = $( this ),
-			    caption              = img.closest( 'figure' ),
-			    imgPos               = img.offset(),
-			    imgPosTop            = imgPos.top,
-			    entryFooter          = img.closest( 'article' ).find( '.entry-footer' ),
-			    entryFooterPos       = entryFooter.offset(),
-			    entryFooterPosBottom = entryFooterPos.top + ( entryFooter.height() + 28 ),
-			    newImg               = new Image();
+				caption              = img.closest( 'figure' ),
+				imgPos               = img.offset(),
+				imgPosTop            = imgPos.top,
+				entryFooter          = img.closest( 'article' ).find( '.entry-footer' ),
+				entryFooterPos       = entryFooter.offset(),
+				entryFooterPosBottom = entryFooterPos.top + ( entryFooter.height() + 28 ),
+				newImg               = new Image();
 
 			newImg.src = img.attr( 'src' );
 

--- a/js/skip-link-focus-fix.js
+++ b/js/skip-link-focus-fix.js
@@ -7,8 +7,8 @@
 
  ( function() {
 	var is_webkit = navigator.userAgent.toLowerCase().indexOf( 'webkit' ) > -1,
-	    is_opera  = navigator.userAgent.toLowerCase().indexOf( 'opera' )  > -1,
-	    is_ie     = navigator.userAgent.toLowerCase().indexOf( 'msie' )   > -1;
+		is_opera  = navigator.userAgent.toLowerCase().indexOf( 'opera' )  > -1,
+		is_ie     = navigator.userAgent.toLowerCase().indexOf( 'msie' )   > -1;
 
 	if ( ( is_webkit || is_opera || is_ie ) && document.getElementById && window.addEventListener ) {
 		window.addEventListener( 'hashchange', function() {


### PR DESCRIPTION
Fixes #107 by replacing spaces with tabs to meet WordPress JS coding standards.
