### PR TITLE
Ditch space before opening parenthesis of function calls.

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -326,7 +326,7 @@ function twentysixteen_color_scheme_css() {
 	$color_textcolor_rgb = twentysixteen_hex2rgb( $color_scheme[3] );
 
 	// If the rgba values are empty return early.
-	if ( empty ( $color_textcolor_rgb ) ) {
+	if ( empty( $color_textcolor_rgb ) ) {
 		return;
 	}
 
@@ -928,7 +928,7 @@ function twentysixteen_main_text_color_css() {
 	$main_text_color_rgb = twentysixteen_hex2rgb( $main_text_color );
 
 	// If the rgba values are empty return early.
-	if ( empty ( $main_text_color_rgb ) ) {
+	if ( empty( $main_text_color_rgb ) ) {
 		return;
 	}
 


### PR DESCRIPTION
There should not be a space between `empty` and its opening parenthesis. This error was picked up by Travis CI. This pull request rectifies the errors and demonstrates what a good Pull Request will look like when Travis CI build results come in and there are actionable errors to fix.

```
FILE: ...wordpress/src/wp-content/themes/twentysixteen/inc/customizer.php
----------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
----------------------------------------------------------------------
 329 | ERROR | [x] Space before opening parenthesis of function call
     |       |     prohibited
     |       |     (PEAR.Functions.FunctionCallSignature.SpaceBeforeOpenBracket)
 931 | ERROR | [x] Space before opening parenthesis of function call
     |       |     prohibited
     |       |     (PEAR.Functions.FunctionCallSignature.SpaceBeforeOpenBracket)
----------------------------------------------------------------------
PHPCBF CAN FIX THE 2 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------
```
