### PR TITLE
Introduce automated Travis CI build testing into Twenty Sixteen.

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -1,0 +1,7 @@
+{
+    "preset": "wordpress",
+    "fileExtensions": [ ".js" ],
+    "excludeFiles": [
+    	"js/html5.js"
+    ]
+}

--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,1 @@
+js/html5.js

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,96 @@
+# Travis CI configuration file.
+# @link https://travis-ci.org/
+
+# For use with the Twenty Sixteen WordPress theme
+# @link https://github.com/WordPress/twentysixteen/
+
+# Declare project language and PHP versions to test against.
+# @link http://about.travis-ci.org/docs/user/languages/php/
+language: php
+
+# Declare versions of PHP to use. Use one decimal max.
+php:
+    - "7.0"
+    - "5.6"
+    - "5.5"
+    - "5.4"
+    - "5.3"
+    # Current $required_php_version for WordPress: 5.2.4
+    - "5.2"
+
+# Ditch sudo and use containers.
+# @link http://docs.travis-ci.com/user/migrating-from-legacy/#Why-migrate-to-container-based-infrastructure%3F
+# @link http://docs.travis-ci.com/user/workers/container-based-infrastructure/#Routing-your-build-to-container-based-infrastructure
+sudo: false
+
+# Declare which versions of WordPress to test against.
+# Also declare whether or not to test in Multisite.
+env:
+    # Trunk (current version in development is 4.4)
+    # @link https://github.com/WordPress/WordPress
+    - WP_VERSION=master WP_MULTISITE=0
+
+# Use this to prepare your build for testing.
+# e.g. copy database configurations, environment variables, etc.
+# Failures in this section will result in build status 'errored'.
+before_script:
+    # Set up WordPress installation.
+    - export WP_DEVELOP_DIR=/tmp/wordpress/
+    - mkdir -p $WP_DEVELOP_DIR
+    # Use the Git mirror of WordPress.
+    - git clone --depth=1 --branch="$WP_VERSION" git://develop.git.wordpress.org/ $WP_DEVELOP_DIR
+    # Set up Twenty Sixteen theme information.
+    - theme_slug=$(basename $(pwd))
+    - theme_dir=$WP_DEVELOP_DIR/src/wp-content/themes/$theme_slug
+    - cd ..
+    - mv $theme_slug $theme_dir
+    # Set up WordPress configuration.
+    - cd $WP_DEVELOP_DIR
+    - echo $WP_DEVELOP_DIR
+    - cp wp-tests-config-sample.php wp-tests-config.php
+    - sed -i "s/youremptytestdbnamehere/wordpress_test/" wp-tests-config.php
+    - sed -i "s/yourusernamehere/root/" wp-tests-config.php
+    - sed -i "s/yourpasswordhere//" wp-tests-config.php
+    # Create WordPress database.
+    - mysql -e 'CREATE DATABASE wordpress_test;' -uroot
+    # Install CodeSniffer for WordPress Coding Standards checks.
+    - mkdir php-codesniffer && curl -L https://github.com/squizlabs/PHP_CodeSniffer/archive/master.tar.gz | tar xz --strip-components=1 -C php-codesniffer
+    # Install WordPress Coding Standards.
+    - mkdir wordpress-coding-standards && curl -L https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/archive/master.tar.gz | tar xz --strip-components=1 -C wordpress-coding-standards
+    # Hop into CodeSniffer directory.
+    - cd php-codesniffer
+    # Set install path for WordPress Coding Standards
+    # @link https://github.com/squizlabs/PHP_CodeSniffer/blob/4237c2fc98cc838730b76ee9cee316f99286a2a7/CodeSniffer.php#L1941
+    - scripts/phpcs --config-set installed_paths ../wordpress-coding-standards
+    # Hop into themes directory.
+    - cd $theme_dir
+    # After CodeSniffer install you should refresh your path.
+    - phpenv rehash
+    # Install JSCS: JavaScript Code Style checker
+    # @link http://jscs.info/
+    - npm install -g jscs
+    # Install JSHint, a JavaScript Code Quality Tool
+    # @link http://jshint.com/docs/
+    - npm install -g jshint
+    - wget https://develop.svn.wordpress.org/trunk/.jshintrc
+
+# Run test script commands.
+# Default is specific to project language.
+# All commands must exit with code 0 on success. Anything else is considered failure.
+script:
+    # Search theme for PHP syntax errors.
+    - find . \( -name '*.php' \) -exec php -lf {} \;
+    # Run the theme through JSHint
+    - jshint .
+    # Run the theme through JavaScript Code Style checker
+    - jscs .
+    # WordPress Coding Standards
+    # @link https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards
+    # @link http://pear.php.net/package/PHP_CodeSniffer/
+    # -p flag: Show progress of the run.
+    # -s flag: Show sniff codes in all reports.
+    # -v flag: Print verbose output.
+    # -n flag: Do not print warnings (shortcut for --warning-severity=0)
+    # --standard: Use WordPress as the standard.
+    # --extensions: Only sniff PHP files.
+    - $WP_DEVELOP_DIR/php-codesniffer/scripts/phpcs -p -s -v -n . --standard=./codesniffer.ruleset.xml --extensions=php

--- a/codesniffer.ruleset.xml
+++ b/codesniffer.ruleset.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruleset name="WordPress Theme Coding Standards">
+	<!-- See https://github.com/squizlabs/PHP_CodeSniffer/wiki/Annotated-ruleset.xml -->
+	<!-- See https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/blob/develop/WordPress-Core/ruleset.xml -->
+
+	<!-- Set a description for this ruleset. -->
+	<description>A custom set of code standard rules to check for WordPress themes.</description>
+
+	<!-- Include the WordPress ruleset, with space for exclusions if necessary. -->
+	<rule ref="WordPress-Core">
+		<exclude name="Generic.WhiteSpace.ScopeIndent.Incorrect" />
+		<exclude name="Generic.WhiteSpace.ScopeIndent.IncorrectExact" />
+
+		<exclude name="PEAR.Functions.FunctionCallSignature.Indent" />
+
+		<exclude name="Squiz.Commenting.FileComment.SpacingAfterComment" />
+		<exclude name="Squiz.Commenting.FunctionComment.MissingParamTag" />
+		<exclude name="Squiz.Commenting.InlineComment.InvalidEndChar" />
+		<exclude name="Squiz.Commenting.InlineComment.NotCapital" />
+	</rule>
+	<rule ref="WordPress-Docs">
+
+	</rule>
+</ruleset>


### PR DESCRIPTION
Introduce automated Travis CI build testing into Twenty Sixteen.

Original Discussion: https://github.com/WordPress/twentysixteen/issues/49

This pull request adds all required files into Twenty Sixteen for automated Travis CI build testing:
- `.jscsrc`: This tells [JSCS](http://jscs.info/) how to scan through Twenty Sixteen and sets the scan preset to WordPress.
- `.jshintignore`: This tells Travis CI to ignore The HTML5 Shiv in its testing.
- `.jshintrc`: This isn't actually part of the PR in the form of a file, but it will be [pulled in from WordPress.org](https://develop.svn.wordpress.org/trunk/.jshintrc) during testing via the Travis CI config file.
- `.travis.yml`: The base file that we need to make all the magic happen. Commented line-by-line for anyone who doesn't fully understand what's happening.
- `codesniffer.ruleset.xml`: This sets the ruleset for our Twenty Sixteen [WordPress Coding Standards](https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards) scans.

**Important note: This DOES NOT solve all issues now caught by Travis CI. This pull request simply adds automated testing into Twenty Sixteen, so that we are able to act on these scan results swiftly and accordingly via their own pull requests. The expectation should not be that Travis CI all of a sudden shows a green, clean repo. The expection should be to see red that we need to fix.**

Here is an example of a Pull Request that has been created due to Travis CI picking up the error in the theme: https://github.com/WordPress/twentysixteen/pull/139

Here is the original output by Travis from this pull request: https://travis-ci.org/philiparthurmoore/twentysixteen/jobs/79455105

JSCS errors should be assessed and fixed in their own pull requests, as well as any errors related to PHP coding standards, of which there currently are a few that will be fixes via separate PRs.

Because a theme is not a plugin and makes much more liberal use of inconsistent tabbing and spacing than plugins, some of the overly-generic Squiz spacing guidelines have been excluded in this pull request. Subsequent pull requests will be created in their own tickets to bring Twenty Sixteen up to par with standards based on these build results.
