### PR TITLE
WordPress Coding Standards: Obey Array Rules

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -18,7 +18,7 @@
 					<?php
 						wp_nav_menu( array(
 							'theme_location' => 'primary',
-							'menu_class'     => 'primary-menu'
+							'menu_class'     => 'primary-menu',
 						 ) );
 					?>
 				</nav><!-- .main-navigation -->

--- a/functions.php
+++ b/functions.php
@@ -92,7 +92,15 @@ function twentysixteen_setup() {
 	 * See: https://codex.wordpress.org/Post_Formats
 	 */
 	add_theme_support( 'post-formats', array(
-		'aside', 'image', 'video', 'quote', 'link', 'gallery', 'status', 'audio', 'chat'
+		'aside',
+		'image',
+		'video',
+		'quote',
+		'link',
+		'gallery',
+		'status',
+		'audio',
+		'chat',
 	) );
 
 	/*

--- a/header.php
+++ b/header.php
@@ -49,7 +49,7 @@
 								<?php
 									wp_nav_menu( array(
 										'theme_location' => 'primary',
-										'menu_class'     => 'primary-menu'
+										'menu_class'     => 'primary-menu',
 									 ) );
 								?>
 							</nav><!-- .main-navigation -->
@@ -63,7 +63,7 @@
 										'menu_class'     => 'social-links-menu',
 										'depth'          => 1,
 										'link_before'    => '<span class="screen-reader-text">',
-										'link_after'     => '</span>'
+										'link_after'     => '</span>',
 									) );
 								?>
 							</nav><!-- .social-navigation -->


### PR DESCRIPTION
This pull request fixes standards errors related to the following rulesets:
- WordPress.Arrays.ArrayDeclaration.NoCommaAfterLast
- WordPress.Arrays.ArrayDeclaration.ValueNoNewline

```
FILE: ...v/www/wordpress-trunk/wp-content/themes/twentysixteen/footer.php
----------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 21 | ERROR | [x] Each line in an array declaration must end in a
    |       |     comma (WordPress.Arrays.ArrayDeclaration.NoComma)
----------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------


FILE: ...ww/wordpress-trunk/wp-content/themes/twentysixteen/functions.php
----------------------------------------------------------------------
FOUND 8 ERRORS AFFECTING 1 LINE
----------------------------------------------------------------------
 95 | ERROR | [x] Each value in a multi-line array must be on a new
    |       |     line (WordPress.Arrays.ArrayDeclaration.ValueNoNewline)
 95 | ERROR | [x] Each value in a multi-line array must be on a new
    |       |     line (WordPress.Arrays.ArrayDeclaration.ValueNoNewline)
 95 | ERROR | [x] Each value in a multi-line array must be on a new
    |       |     line (WordPress.Arrays.ArrayDeclaration.ValueNoNewline)
 95 | ERROR | [x] Each value in a multi-line array must be on a new
    |       |     line (WordPress.Arrays.ArrayDeclaration.ValueNoNewline)
 95 | ERROR | [x] Each value in a multi-line array must be on a new
    |       |     line (WordPress.Arrays.ArrayDeclaration.ValueNoNewline)
 95 | ERROR | [x] Each value in a multi-line array must be on a new
    |       |     line (WordPress.Arrays.ArrayDeclaration.ValueNoNewline)
 95 | ERROR | [x] Each value in a multi-line array must be on a new
    |       |     line (WordPress.Arrays.ArrayDeclaration.ValueNoNewline)
 95 | ERROR | [x] Comma required after last value in array
    |       |     declaration
    |       |     (WordPress.Arrays.ArrayDeclaration.NoCommaAfterLast)
----------------------------------------------------------------------
PHPCBF CAN FIX THE 8 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------


FILE: ...v/www/wordpress-trunk/wp-content/themes/twentysixteen/header.php
----------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
----------------------------------------------------------------------
 52 | ERROR | [x] Each line in an array declaration must end in a
    |       |     comma (WordPress.Arrays.ArrayDeclaration.NoComma)
 66 | ERROR | [x] Each line in an array declaration must end in a
    |       |     comma (WordPress.Arrays.ArrayDeclaration.NoComma)
----------------------------------------------------------------------
PHPCBF CAN FIX THE 2 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------
```

This pull request, combined with https://github.com/WordPress/twentysixteen/pull/139, will bring Twenty Sixteen completely up to snuff with WordPress Coding Standards.
