### PR TITLE
bleeding blockquote over to post meta bug fix

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -138,21 +138,18 @@
 		// jscs:disable
 		var entryContent = $( '.entry-content' );
 		// jscs:enable
-
 		entryContent.find( param ).each( function() {
 			var element              = $( this ),
 				elementPos           = element.offset(),
 				elementPosTop        = elementPos.top,
 				entryFooter          = element.closest( 'article' ).find( '.entry-footer' ),
 				entryFooterPos       = entryFooter.offset(),
-				entryFooterPosBottom = entryFooterPos.top + ( entryFooter.height() + 28 );
+				entryFooterPosBottom = entryFooterPos.top + ( entryFooter.height() + 28 ),
+				caption              = element.closest( 'figure' ),
+				newImg               = new Image();
 			
 			// Add a class to big image and caption larger than or equal to 840px.
 			if ( 'img.size-full' == param ) {
-
-				var caption              = element.closest( 'figure' ),
-					newImg               = new Image();
-
 				newImg.src = element.attr( 'src' );
 
 				$( newImg ).load( function() {

--- a/js/functions.js
+++ b/js/functions.js
@@ -168,6 +168,22 @@
 				}
 			} );
 		} );
+
+		// Prevent blockquote on the top of the post from bleeding over to post meta
+		entryContent.find( 'blockquote.alignleft' ).each( function() {
+			var blockquote           = $( this ),
+				blockquotePos        = blockquote.offset(),
+				blockquotePosTop     = blockquotePos.top,
+				entryFooter          = blockquote.closest( 'article' ).find( '.entry-footer' ),
+				entryFooterPos       = entryFooter.offset(),
+				entryFooterPosBottom = entryFooterPos.top + ( entryFooter.height() + 28 );
+
+			if ( blockquotePosTop > entryFooterPosBottom ) {
+				blockquote.addClass( 'farleft' );
+			} else {
+				blockquote.removeClass( 'farleft' );
+			}
+		} );
 	}
 
 	$( document ).ready( function() {

--- a/js/functions.js
+++ b/js/functions.js
@@ -147,7 +147,7 @@
 				entryFooterPosBottom = entryFooterPos.top + ( entryFooter.height() + 28 ),
 				caption              = element.closest( 'figure' ),
 				newImg               = new Image();
-			
+
 			// Add a class to big image and caption larger than or equal to 840px.
 			if ( 'img.size-full' == param ) {
 				newImg.src = element.attr( 'src' );

--- a/js/functions.js
+++ b/js/functions.js
@@ -147,8 +147,8 @@
 				entryFooterPos       = entryFooter.offset(),
 				entryFooterPosBottom = entryFooterPos.top + ( entryFooter.height() + 28 );
 			
-			// Add a class to big image and caption larger than or equal to 840px.	
-			if ( param == 'img.size-full' ) {
+			// Add a class to big image and caption larger than or equal to 840px.
+			if ( 'img.size-full' == param ) {
 
 				var caption              = element.closest( 'figure' ),
 					newImg               = new Image();
@@ -163,7 +163,7 @@
 							element.addClass( 'size-big' );
 						}
 
-						if ( caption.hasClass( 'wp-caption' ) && imgWidth >= 840) {
+						if ( caption.hasClass( 'wp-caption' ) && imgWidth >= 840 ) {
 							caption.addClass( 'caption-big' );
 							caption.removeAttr( 'style' );
 						}
@@ -175,7 +175,7 @@
 			}
 
 			// Prevent blockquote on the top of the post from bleeding over to post meta
-			if ( param == 'blockquote.alignleft' ) {
+			if ( 'blockquote.alignleft' == param ) {
 				if ( elementPosTop > entryFooterPosBottom ) {
 					element.addClass( 'farleft' );
 				} else {

--- a/js/functions.js
+++ b/js/functions.js
@@ -169,7 +169,15 @@
 			} );
 		} );
 
-		// Prevent blockquote on the top of the post from bleeding over to post meta
+	}
+
+	// Prevent blockquote on the top of the post from bleeding over to post meta
+	function blockquoteFix() {
+		if ( $body.hasClass( 'page' ) || $body.hasClass( 'search' ) || $body.hasClass( 'single-attachment' ) || $body.hasClass( 'error404' ) ) {
+			return;
+		}
+
+		var entryContent = $( '.entry-content' );
 		entryContent.find( 'blockquote.alignleft' ).each( function() {
 			var blockquote           = $( this ),
 				blockquotePos        = blockquote.offset(),
@@ -198,5 +206,6 @@
 			} );
 
 		bigImageClass();
+		blockquoteFix();
 	} );
 } )( jQuery );

--- a/js/functions.js
+++ b/js/functions.js
@@ -149,7 +149,7 @@
 				newImg               = new Image();
 
 			// Add a class to big image and caption larger than or equal to 840px.
-			if ( 'img.size-full' == param ) {
+			if ( 'img.size-full' === param ) {
 				newImg.src = element.attr( 'src' );
 
 				$( newImg ).load( function() {
@@ -172,7 +172,7 @@
 			}
 
 			// Prevent blockquote on the top of the post from bleeding over to post meta
-			if ( 'blockquote.alignleft' == param ) {
+			if ( 'blockquote.alignleft' === param ) {
 				if ( elementPosTop > entryFooterPosBottom ) {
 					element.addClass( 'farleft' );
 				} else {

--- a/js/functions.js
+++ b/js/functions.js
@@ -129,8 +129,8 @@
 		}
 	}
 
-	// Add a class to big image and caption larger than or equal to 840px.
-	function bigImageClass() {
+	// Preventing left offseted elements to bleed into the post meta
+	function offsetLeft( param ) {
 		if ( $body.hasClass( 'page' ) || $body.hasClass( 'search' ) || $body.hasClass( 'single-attachment' ) || $body.hasClass( 'error404' ) ) {
 			return;
 		}
@@ -138,59 +138,51 @@
 		// jscs:disable
 		var entryContent = $( '.entry-content' );
 		// jscs:enable
-		entryContent.find( 'img.size-full' ).each( function() {
-			var img                  = $( this ),
-				caption              = img.closest( 'figure' ),
-				imgPos               = img.offset(),
-				imgPosTop            = imgPos.top,
-				entryFooter          = img.closest( 'article' ).find( '.entry-footer' ),
-				entryFooterPos       = entryFooter.offset(),
-				entryFooterPosBottom = entryFooterPos.top + ( entryFooter.height() + 28 ),
-				newImg               = new Image();
 
-			newImg.src = img.attr( 'src' );
-
-			$( newImg ).load( function() {
-				var imgWidth = newImg.width;
-
-				if ( imgPosTop > entryFooterPosBottom ) {
-					if ( imgWidth >= 840 ) {
-						img.addClass( 'size-big' );
-					}
-
-					if ( caption.hasClass( 'wp-caption' ) && imgWidth >= 840 ) {
-						caption.addClass( 'caption-big' );
-						caption.removeAttr( 'style' );
-					}
-				} else {
-					img.removeClass( 'size-big' );
-					caption.removeClass( 'caption-big' );
-				}
-			} );
-		} );
-
-	}
-
-	// Prevent blockquote on the top of the post from bleeding over to post meta
-	function blockquoteFix() {
-		if ( $body.hasClass( 'page' ) || $body.hasClass( 'search' ) || $body.hasClass( 'single-attachment' ) || $body.hasClass( 'error404' ) ) {
-			return;
-		}
-
-		var entryContent = $( '.entry-content' );
-		entryContent.find( 'blockquote.alignleft' ).each( function() {
-			var blockquote           = $( this ),
-				blockquotePos        = blockquote.offset(),
-				blockquotePosTop     = blockquotePos.top,
-				entryFooter          = blockquote.closest( 'article' ).find( '.entry-footer' ),
+		entryContent.find( param ).each( function() {
+			var element              = $( this ),
+				elementPos           = element.offset(),
+				elementPosTop        = elementPos.top,
+				entryFooter          = element.closest( 'article' ).find( '.entry-footer' ),
 				entryFooterPos       = entryFooter.offset(),
 				entryFooterPosBottom = entryFooterPos.top + ( entryFooter.height() + 28 );
+			
+			// Add a class to big image and caption larger than or equal to 840px.	
+			if ( 'img.size-full' == param ) {
 
-			if ( blockquotePosTop > entryFooterPosBottom ) {
-				blockquote.addClass( 'farleft' );
-			} else {
-				blockquote.removeClass( 'farleft' );
+				var caption              = element.closest( 'figure' ),
+					newImg               = new Image();
+
+				newImg.src = element.attr( 'src' );
+
+				$( newImg ).load( function() {
+					var imgWidth = newImg.width;
+
+					if ( elementPosTop > entryFooterPosBottom ) {
+						if ( 840 <= imgWidth  ) {
+							element.addClass( 'size-big' );
+						}
+
+						if ( caption.hasClass( 'wp-caption' ) && 840 <= imgWidth  ) {
+							caption.addClass( 'caption-big' );
+							caption.removeAttr( 'style' );
+						}
+					} else {
+						element.removeClass( 'size-big' );
+						caption.removeClass( 'caption-big' );
+					}
+				} );
 			}
+
+			// Prevent blockquote on the top of the post from bleeding over to post meta
+			if ( 'blockquote.alignleft' == param ) {
+				if ( elementPosTop > entryFooterPosBottom ) {
+					element.addClass( 'farleft' );
+				} else {
+					element.removeClass( 'farleft' );
+				}
+			}
+
 		} );
 	}
 
@@ -201,11 +193,11 @@
 			.on( 'load.twentysixteen', onResizeARIA )
 			.on( 'resize.twentysixteen', function() {
 				clearTimeout( resizeTimer );
-				resizeTimer = setTimeout( bigImageClass, 300 );
+				resizeTimer = setTimeout( offsetLeft, 300 );
 				onResizeARIA();
 			} );
 
-		bigImageClass();
-		blockquoteFix();
+		offsetLeft( 'img.size-full' );
+		offsetLeft( 'blockquote.alignleft' );
 	} );
 } )( jQuery );

--- a/js/functions.js
+++ b/js/functions.js
@@ -148,7 +148,7 @@
 				entryFooterPosBottom = entryFooterPos.top + ( entryFooter.height() + 28 );
 			
 			// Add a class to big image and caption larger than or equal to 840px.	
-			if ( 'img.size-full' == param ) {
+			if ( param == 'img.size-full' ) {
 
 				var caption              = element.closest( 'figure' ),
 					newImg               = new Image();
@@ -159,11 +159,11 @@
 					var imgWidth = newImg.width;
 
 					if ( elementPosTop > entryFooterPosBottom ) {
-						if ( 840 <= imgWidth  ) {
+						if ( imgWidth >= 840  ) {
 							element.addClass( 'size-big' );
 						}
 
-						if ( caption.hasClass( 'wp-caption' ) && 840 <= imgWidth  ) {
+						if ( caption.hasClass( 'wp-caption' ) && imgWidth >= 840) {
 							caption.addClass( 'caption-big' );
 							caption.removeAttr( 'style' );
 						}
@@ -175,7 +175,7 @@
 			}
 
 			// Prevent blockquote on the top of the post from bleeding over to post meta
-			if ( 'blockquote.alignleft' == param ) {
+			if ( param == 'blockquote.alignleft' ) {
 				if ( elementPosTop > entryFooterPosBottom ) {
 					element.addClass( 'farleft' );
 				} else {

--- a/style.css
+++ b/style.css
@@ -3445,12 +3445,8 @@ p > video {
 		width: 71.42857144%;
 	}
 
-	body:not(.search-results) .type-post .entry-content blockquote.alignleft.farleft {
+	body:not(.search-results) .type-post .entry-content blockquote.farleft {
 		margin-left: -40%;
-	}
-
-	body:not(.search-results) .type-post .entry-content blockquote.alignleft {
-		margin-left: 0;
 		width: -webkit-calc(60% - 1.4736842105em);
 		width: calc(60% - 1.4736842105em);
 	}

--- a/style.css
+++ b/style.css
@@ -3445,8 +3445,12 @@ p > video {
 		width: 71.42857144%;
 	}
 
-	body:not(.search-results) .type-post .entry-content blockquote.alignleft {
+	body:not(.search-results) .type-post .entry-content blockquote.alignleft.farleft {
 		margin-left: -40%;
+	}
+
+	body:not(.search-results) .type-post .entry-content blockquote.alignleft {
+		margin-left: 0;
 		width: -webkit-calc(60% - 1.4736842105em);
 		width: calc(60% - 1.4736842105em);
 	}


### PR DESCRIPTION
Trying to fix blockquote bleeding over to post meta bug ref: https://github.com/WordPress/twentysixteen/issues/32

I am no JS wiz and I am pretty sure there are better ways to organize and do things. I just copied over the big image code and tried to adjust.

Here are the screenshots:

![blockquote-fix2](https://cloud.githubusercontent.com/assets/883993/9803696/ddc0a088-5844-11e5-961c-067359c91790.jpg)

![blockquote-fix1](https://cloud.githubusercontent.com/assets/883993/9803697/ddc3dae6-5844-11e5-985e-97b1080b9930.jpg)
