### PR TITLE
Improve gallery styling by making the space consistent

### DIFF
--- a/style.css
+++ b/style.css
@@ -2443,12 +2443,14 @@ p > video {
 
 .gallery {
 	margin-bottom: 1.75em;
+	margin-left: -1.1666667%;
+	margin-right: -1.1666667%;
 }
 
 .gallery-item {
 	display: inline-block;
 	text-align: center;
-	padding: 0 2.3333333% 2.3333333%;
+	padding: 0 1.1666667% 2.3333333%;
 	vertical-align: top;
 	width: 100%;
 }

--- a/style.css
+++ b/style.css
@@ -2442,15 +2442,13 @@ p > video {
  */
 
 .gallery {
-	margin-bottom: 1.75em;
-	margin-left: -1.1666667%;
-	margin-right: -1.1666667%;
+	margin: 0 -1.1666667% 1.75em;
 }
 
 .gallery-item {
 	display: inline-block;
 	text-align: center;
-	padding: 0 1.1666667% 2.3333333%;
+	padding: 0 1.1400652% 2.2801304%;
 	vertical-align: top;
 	width: 100%;
 }


### PR DESCRIPTION
At the moment, the spacing between `.gallery-item` is not consistent vertically/horizontally. Plus, the left side of the gallery is not aligned with the content.

**Preview**

Before:

![gallery-before](https://cloud.githubusercontent.com/assets/3433880/9808781/1e78c38a-5895-11e5-8a0d-d8f048d632d6.png)

After:

![gallery-after](https://cloud.githubusercontent.com/assets/3433880/9808785/2689e126-5895-11e5-8bed-b5e2d8d640e6.png)

The editor-style.css update will be submitted in another PR.
