### PR TITLE
Bring gallery styling for wp editor up-to-date with frontend

### DIFF
--- a/css/editor-style.css
+++ b/css/editor-style.css
@@ -408,9 +408,15 @@ a {
  * 6.0 Galleries
  */
 
-.gallery-item {
+.gallery {
+    margin-bottom: 1.75em;
+    margin-left: -1.1666667%;
+    margin-right: -1.1666667%;
+}
+
+.gallery .gallery-item {
 	display: inline-block;
-	padding: 0 2.3333333% 2.3333333%;
+	padding: 0 1.1666667% 2.3333333%;
 	text-align: center;
 	vertical-align: top;
 	width: 100%;

--- a/css/editor-style.css
+++ b/css/editor-style.css
@@ -409,14 +409,12 @@ a {
  */
 
 .gallery {
-    margin-bottom: 1.75em;
-    margin-left: -1.1666667%;
-    margin-right: -1.1666667%;
+    margin: 0 -1.1666667% 1.75em;
 }
 
 .gallery .gallery-item {
 	display: inline-block;
-	padding: 0 1.1666667% 2.3333333%;
+	padding: 0 1.1400652% 2.2801304%;
 	text-align: center;
 	vertical-align: top;
 	width: 100%;


### PR DESCRIPTION
Related to [#154](https://github.com/WordPress/twentysixteen/pull/154)

Consistent spacing is applied to `.gallery-item`. The `.gallery-item` selector is also prepended with `.gallery` since the padding style is overriden by WP editor style.

**Preview**

Before:

![gallery-editor-before](https://cloud.githubusercontent.com/assets/3433880/9808835/8c2b34b2-5895-11e5-8044-eb650962d905.png)

After:

![gallery-editor-after](https://cloud.githubusercontent.com/assets/3433880/9808840/92cc7538-5895-11e5-8e44-d5bbaac4006a.png)
