### PR TITLE
Fix long non-breaking post title overflowing to the sidebar

### DIFF
--- a/style.css
+++ b/style.css
@@ -2733,6 +2733,9 @@ p > video {
 		font-size: 2.0625rem;
 		line-height: 1.2727272727;
 		margin-bottom: 0.8484848485em;
+		word-break: break-all;
+		word-break: break-word; /* Non standard for webkit/blink */
+		hyphens: auto;
 	}
 
 	.entry-content blockquote:not(.alignleft):not(.alignright),


### PR DESCRIPTION
**Preview**

Before:

![before-1](https://cloud.githubusercontent.com/assets/3433880/9809668/f12e1e7c-589c-11e5-8f04-fe02d5d713ad.png)

After:

![after](https://cloud.githubusercontent.com/assets/3433880/9809678/0132c016-589d-11e5-85ed-afa1c2589980.png)
