### PR TITLE
Minor "skip to content" JS fixes to better fit JSCS standards.

### DIFF
--- a/js/skip-link-focus-fix.js
+++ b/js/skip-link-focus-fix.js
@@ -6,11 +6,11 @@
  */
 
  ( function() {
-	var is_webkit = navigator.userAgent.toLowerCase().indexOf( 'webkit' ) > -1,
-		is_opera  = navigator.userAgent.toLowerCase().indexOf( 'opera' )  > -1,
-		is_ie     = navigator.userAgent.toLowerCase().indexOf( 'msie' )   > -1;
+	var isWebkit = navigator.userAgent.toLowerCase().indexOf( 'webkit' ) > -1,
+		isOpera  = navigator.userAgent.toLowerCase().indexOf( 'opera' )  > -1,
+		isIE     = navigator.userAgent.toLowerCase().indexOf( 'msie' )   > -1;
 
-	if ( ( is_webkit || is_opera || is_ie ) && document.getElementById && window.addEventListener ) {
+	if ( ( isWebkit || isOpera || isIE ) && document.getElementById && window.addEventListener ) {
 		window.addEventListener( 'hashchange', function() {
 			var id = location.hash.substring( 1 ),
 				element;


### PR DESCRIPTION
This PR fixes all errors associated with the "All identifiers must be camelCase or UPPER_CASE" JSCS standard in the skip to content JS file. See #143 and #140.
