### PR TITLE
JSCS: Temporarily ignore minor errors associated with Customizer color scheme handling.

### DIFF
--- a/js/color-scheme-control.js
+++ b/js/color-scheme-control.js
@@ -71,7 +71,9 @@
 		} );
 
 		// Add additional color.
+		// jscs:disable
 		colors.border_color = Color( colors.main_text_color ).toCSS( 'rgba', 0.1 );
+		// jscs:enable
 
 		css = cssTemplate( colors );
 


### PR DESCRIPTION
The cure, in this case, would have been worse than the disease. Better to exclude this line for now instead of rocking the boat on 2016’s customizer color JS handling.

See #143 and #140.
