### PR TITLE
JSCS: Fix remaining non-issues and bring Twenty Sixteen green across all standards checks.

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -25,7 +25,10 @@
 			e.preventDefault();
 			_this.toggleClass( 'toggled-on' );
 			_this.next( '.children, .sub-menu' ).toggleClass( 'toggled-on' );
+
+			// jscs:disable
 			_this.attr( 'aria-expanded', _this.attr( 'aria-expanded' ) === 'false' ? 'true' : 'false' );
+			// jscs:enable
 			_this.html( _this.html() === screenReaderText.expand ? screenReaderText.collapse : screenReaderText.expand );
 		} );
 	}
@@ -50,7 +53,10 @@
 
 		menuToggle.on( 'click.twentysixteen', function() {
 			$( this ).add( siteHeaderMenu ).toggleClass( 'toggled-on' );
+
+			// jscs:disable
 			$( this ).add( siteNavigation ).add( socialNavigation ).attr( 'aria-expanded', $( this ).add( siteNavigation ).add( socialNavigation ).attr( 'aria-expanded' ) === 'false' ? 'true' : 'false' );
+			// jscs:enable
 		} );
 	} )();
 
@@ -109,7 +115,9 @@
 			return;
 		}
 
+		// jscs:disable
 		var entryContent = $( '.entry-content' );
+		// jscs:enable
 		entryContent.find( 'img.size-full' ).each( function() {
 			var img                  = $( this ),
 				caption              = img.closest( 'figure' ),


### PR DESCRIPTION
See the line of reasoning for ignoring these lines here:
https://github.com/WordPress/twentysixteen/issues/143#issuecomment-139396092

@ihorvorotnov I agree with you completely on a lot of this, as well as Takashi.

This commit should result in a green check for Travis, as all standards issues related to automated testing are now fixed and complete.

See #143 and #140.

Note that spaces are needed above line comments, so I've added those in in two spots.
