### PR TITLE
Remove redundant display declaration when using float

### DIFF
--- a/style.css
+++ b/style.css
@@ -1273,13 +1273,11 @@ a:active {
  */
 
 .alignleft {
-	display: inline;
 	float: left;
 	margin: 0.375em 1.75em 1.75em 0;
 }
 
 .alignright {
-	display: inline;
 	float: right;
 	margin: 0.375em 0 1.75em 1.75em;
 }
@@ -2881,7 +2879,6 @@ p > video {
 
 	.main-navigation ul ul {
 		border-bottom: 1px solid #e8e8e8;
-		display: block;
 		float: left;
 		margin: 0;
 		position: absolute;

--- a/style.css
+++ b/style.css
@@ -2879,6 +2879,7 @@ p > video {
 
 	.main-navigation ul ul {
 		border-bottom: 1px solid #e8e8e8;
+		display: block;
 		float: left;
 		margin: 0;
 		position: absolute;


### PR DESCRIPTION
When using `float` with value other than `none`, the `display` will be automatically set to `block`. So we can clean up the code a bit by removing the unnecessary `display` declaration.
