### PR TITLE
Add fix for alignleft blockquote. Fixes #32.

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -160,6 +160,32 @@
 		} );
 	}
 
+	// Add class to left-aligned blockquotes that clear the entry footer.
+	function leftAlignedBlockquoteClass() {
+		if ( $body.hasClass( 'page' ) || $body.hasClass( 'search' ) || $body.hasClass( 'single-attachment' ) || $body.hasClass( 'error404' ) ) {
+			return;
+		}
+
+		// jscs:disable
+		var entryContent = $( '.entry-content' );
+		// jscs:enable
+		entryContent.find( 'blockquote.alignleft' ).each( function() {
+			var blockquote           = $( this ),
+				blockquotePos        = blockquote.offset(),
+				blockquotePosTop     = blockquotePos.top,
+				entryFooter          = blockquote.closest( 'article' ).find( '.entry-footer' ),
+				entryFooterPos       = entryFooter.offset(),
+				entryFooterPosBottom = entryFooterPos.top + ( entryFooter.height() + 28 );
+
+			if ( blockquotePosTop > entryFooterPosBottom ) {
+				blockquote.addClass( 'pull-left' );
+			} else {
+				blockquote.removeClass( 'pull-left' );
+			}
+
+		} );
+	}
+
 	$( document ).ready( function() {
 		$body = $( document.body );
 
@@ -167,10 +193,14 @@
 			.on( 'load.twentysixteen', onResizeARIA )
 			.on( 'resize.twentysixteen', function() {
 				clearTimeout( resizeTimer );
-				resizeTimer = setTimeout( bigImageClass, 300 );
+				resizeTimer = setTimeout( function() {
+					bigImageClass();
+					leftAlignedBlockquoteClass();
+				}, 300 );
 				onResizeARIA();
 			} );
 
 		bigImageClass();
+		leftAlignedBlockquoteClass();
 	} );
 } )( jQuery );

--- a/style.css
+++ b/style.css
@@ -4,7 +4,7 @@ Theme URI: https://wordpress.org/themes/twentysixteen/
 Author: the WordPress team
 Author URI: https://wordpress.org/
 Description: Twenty Sixteen is a modernized take on an ever-popular WordPress layout — the horizontal masthead with an optional right sidebar that works perfectly for blogs and websites. It has custom color options with beautiful default color schemes, a harmonious fluid grid using a mobile-first approach, and impeccable polish in every detail. Twenty Sixteen will make your WordPress look beautiful everywhere.
-Version: 0.1.20150828
+Version: 0.1.20150915
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Tags: black, blue, gray, green, white, yellow, dark, light, one-column, two-columns, right-sidebar, fixed-layout, responsive-layout, accessibility-ready, custom-background, custom-colors, custom-header, custom-menu, editor-style, featured-images, flexible-header, microformats, post-formats, sticky-post, threaded-comments, translation-ready
@@ -3377,9 +3377,13 @@ p > video {
 	}
 
 	body:not(.search-results) .type-post .entry-content blockquote.alignleft {
-		margin-left: -40%;
 		width: -webkit-calc(60% - 1.4736842105em);
 		width: calc(60% - 1.4736842105em);
+	}
+
+	body:not(.search-results) .type-post .entry-content blockquote.alignleft.pull-left {
+		clear: left;
+		margin-left: -40%;
 	}
 
 	body:not(.search-results) .type-post .size-big,


### PR DESCRIPTION
This PR attempts to fix #32. It solves the issue described specifically for left-aligned blockquotes, and assumes that this is the only element for which the issue still occurs. If there are other known elements/layouts for which the issue arises (left-pulled elements colliding with the entry-footer), then a more generalized solution is in order.
