### PR TITLE
Replace spaces with tab to meet js coding standards.

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -30,7 +30,7 @@
 
 		container.find( '.dropdown-toggle' ).click( function( e ) {
 			var _this            = $( this ),
-			    screenReaderSpan = _this.find( '.screen-reader-text' );
+				screenReaderSpan = _this.find( '.screen-reader-text' );
 
 			e.preventDefault();
 			_this.toggleClass( 'toggled-on' );


### PR DESCRIPTION
Multi-line var declarations should be spaced with tabs, not spaces, as described in the [standards here](https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/#declaring-variables-with-var).

This was previously resolved in #134 but an instance of it was reintroduced in #174.
