### PR TITLE
Remove redundant has_nav_menu checks for both social and primary menus.

### DIFF
--- a/header.php
+++ b/header.php
@@ -40,9 +40,7 @@
 
 				<?php if ( has_nav_menu( 'primary' ) || has_nav_menu( 'social' ) ) : ?>
 					<button id="menu-toggle" class="menu-toggle"><?php esc_html_e( 'Menu', 'twentysixteen' ); ?></button>
-				<?php endif; ?>
 
-				<?php if ( has_nav_menu( 'primary' ) || has_nav_menu( 'social' ) ) : ?>
 					<div id="site-header-menu" class="site-header-menu">
 						<?php if ( has_nav_menu( 'primary' ) ) : ?>
 							<nav id="site-navigation" class="main-navigation" role="navigation">


### PR DESCRIPTION
This should be self-explanatory.

Discussion here: https://wordpress.slack.com/archives/core-themes/p1442405958000683
