### PR TITLE
Better selector to target hentry

### DIFF
--- a/style.css
+++ b/style.css
@@ -1324,8 +1324,8 @@ blockquote.aligncenter {
 .site-content:after,
 .site-footer:before,
 .site-footer:after,
-article[class^="post-"]:before,
-article[class^="post-"]:after,
+.site-main > article:before,
+.site-main > article:after,
 .primary-menu:before,
 .primary-menu:after,
 .social-links-menu:before,
@@ -1344,7 +1344,7 @@ article[class^="post-"]:after,
 .comment-content:after,
 .site-content:after,
 .site-footer:after,
-article[class^="post-"]:after,
+.site-main > article:after,
 .primary-menu:after,
 .social-links-menu:after,
 .textwidget:after,
@@ -1597,7 +1597,7 @@ article[class^="post-"]:after,
  * 11.2 - Posts and pages
  */
 
-article[class^="post-"] {
+.site-main > article {
 	margin-bottom: 3.5em;
 	position: relative;
 }
@@ -2753,7 +2753,7 @@ p > video {
 		font-weight: 400;
 	}
 
-	article[class^="post-"] {
+	.site-main > article {
 		margin-bottom: 5.25em;
 	}
 
@@ -3335,7 +3335,7 @@ p > video {
 		margin-bottom: 4.307692308em;
 	}
 
-	article[class^="post-"] {
+	.site-main > article {
 		margin-bottom: 7.0em;
 	}
 


### PR DESCRIPTION
[As discussed in the meeting](https://wordpress.slack.com/archives/core-themes/p1442247547000588)  we're going for `.site-main > article` as a replacement of `hentry`. Fixes #209
