### PR TITLE
Remove float for absolute positioned element

### DIFF
--- a/style.css
+++ b/style.css
@@ -2933,7 +2933,6 @@ p > video {
 	.main-navigation ul ul {
 		border-bottom: 1px solid #e8e8e8;
 		display: block;
-		float: left;
 		left: -999em;
 		margin: 0;
 		position: absolute;


### PR DESCRIPTION
Since we are absolute positioning the submenu, float is not needed anymore.
