### PR TITLE
Gallery shortcode: default to three columns

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -22,3 +22,4 @@
 @eduardozulian
 @webdevmattcrom
 @ehtis
+@peterwilsoncc

--- a/css/editor-style.css
+++ b/css/editor-style.css
@@ -419,14 +419,15 @@ a {
 	text-align: center;
 	vertical-align: top;
 	width: 100%;
+	max-width: 33.33%;
+}
+
+.gallery-columns-1 .gallery-item {
+	max-width: 100%;
 }
 
 .gallery-columns-2 .gallery-item {
 	max-width: 50%;
-}
-
-.gallery-columns-3 .gallery-item {
-	max-width: 33.33%;
 }
 
 .gallery-columns-4 .gallery-item {

--- a/style.css
+++ b/style.css
@@ -2474,14 +2474,15 @@ p > video {
 	text-align: center;
 	vertical-align: top;
 	width: 100%;
+	max-width: 33.33%;
+}
+
+.gallery-columns-1 .gallery-item {
+	max-width: 100%;
 }
 
 .gallery-columns-2 .gallery-item {
 	max-width: 50%;
-}
-
-.gallery-columns-3 .gallery-item {
-	max-width: 33.33%;
 }
 
 .gallery-columns-4 .gallery-item {


### PR DESCRIPTION
By default, `[galley]` displays three columns.

Follow this guideline if an out of range/invalid number is entered in the shortcode manually.
