### PR TITLE
Add `aria-label`s to `nav` elements for better specificity

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -14,7 +14,7 @@
 
 		<footer id="colophon" class="site-footer" role="contentinfo">
 			<?php if ( has_nav_menu( 'primary' ) ) : ?>
-				<nav class="main-navigation" role="navigation">
+				<nav class="main-navigation" role="navigation" aria-label='<?php _e( 'Footer Primary Menu', 'twentysixteen' ); ?>'>
 					<?php
 						wp_nav_menu( array(
 							'theme_location' => 'primary',
@@ -25,7 +25,7 @@
 			<?php endif; ?>
 
 			<?php if ( has_nav_menu( 'social' ) ) : ?>
-				<nav class="social-navigation" role="navigation">
+				<nav class="social-navigation" role="navigation" aria-label='<?php _e( 'Footer Social Links Menu', 'twentysixteen' ); ?>'>
 					<?php
 						wp_nav_menu( array(
 							'theme_location' => 'social',

--- a/header.php
+++ b/header.php
@@ -43,7 +43,7 @@
 
 					<div id="site-header-menu" class="site-header-menu">
 						<?php if ( has_nav_menu( 'primary' ) ) : ?>
-							<nav id="site-navigation" class="main-navigation" role="navigation">
+							<nav id="site-navigation" class="main-navigation" role="navigation" aria-label='<?php _e( 'Primary Menu', 'twentysixteen' ); ?>'>
 								<?php
 									wp_nav_menu( array(
 										'theme_location' => 'primary',
@@ -54,7 +54,7 @@
 						<?php endif; ?>
 
 						<?php if ( has_nav_menu( 'social' ) ) : ?>
-							<nav id="social-navigation" class="social-navigation" role="navigation">
+							<nav id="social-navigation" class="social-navigation" role="navigation" aria-label='<?php _e( 'Social Links Menu', 'twentysixteen' ); ?>'>
 								<?php
 									wp_nav_menu( array(
 										'theme_location' => 'social',


### PR DESCRIPTION
- This helps these landmarks with the same role be more specific and useful to users with assistive technology.
- I've used the word "Footer" to make the ones in the `footer` be unique, but we may prefer a different word choice.

Resolves #236
