### PR TITLE
Reset `word-wrap` for `screen-reader-text`

### DIFF
--- a/style.css
+++ b/style.css
@@ -1239,6 +1239,8 @@ a:active {
 	overflow: hidden;
 	position: absolute !important;
 	width: 1px;
+	/* many screen reader and browser combinations announce broken words as they would appear visually */
+	word-wrap: normal !important;
 }
 
 /* must have higher specificity than alternative color schemes inline styles */


### PR DESCRIPTION
- Ensure screen reader text is read as words and not affected by word-wrap.

Resolves #235
See: https://core.trac.wordpress.org/changeset/32509
