### PR TITLE
Split translation with HTML

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -23,3 +23,4 @@
 @webdevmattcrom
 @ehtis
 @peterwilsoncc
+@tfrommen

--- a/template-parts/content-none.php
+++ b/template-parts/content-none.php
@@ -18,7 +18,13 @@
 	<div class="page-content">
 		<?php if ( is_home() && current_user_can( 'publish_posts' ) ) : ?>
 
-			<p><?php printf( wp_kses( __( 'Ready to publish your first post? <a href="%1$s">Get started here</a>.', 'twentysixteen' ), array( 'a' => array( 'href' => array() ) ) ), esc_url( admin_url( 'post-new.php' ) ) ); ?></p>
+			<p><?php
+				printf(
+					/* translators: %s: Link to post-new.php */
+					__( 'Ready to publish your first post? %s.', 'twentysixteen' ),
+					'<a href="' . esc_url( admin_url( 'post-new.php' ) ) . '">' . __( 'Get started here', 'twentysixteen' ) . '</a>'
+				);
+			?></p>
 
 		<?php elseif ( is_search() ) : ?>
 

--- a/template-parts/content-none.php
+++ b/template-parts/content-none.php
@@ -21,8 +21,8 @@
 			<p><?php
 				printf(
 					/* translators: %s: Link to post-new.php */
-					__( 'Ready to publish your first post? %s.', 'twentysixteen' ),
-					'<a href="' . esc_url( admin_url( 'post-new.php' ) ) . '">' . __( 'Get started here', 'twentysixteen' ) . '</a>'
+					esc_html__( 'Ready to publish your first post? %s.', 'twentysixteen' ),
+					'<a href="' . esc_url( admin_url( 'post-new.php' ) ) . '">' . esc_html__( 'Get started here', 'twentysixteen' ) . '</a>'
 				);
 			?></p>
 


### PR DESCRIPTION
This pull request splits a string in order to not have HTML markup translated. No `wp_kses()` required. @ocean90 
