### PR TITLE
Use placeholder in both translation strings in _nx()

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -26,6 +26,7 @@ if ( post_password_required() ) {
 		<h2 class="comments-title">
 			<?php
 				printf(
+					/* translators: %1$s: number of comments, %2$s: post title */
 					_nx(
 						'%1$s thought on &ldquo;%2$s&rdquo;',
 						'%1$s thoughts on &ldquo;%2$s&rdquo;',

--- a/comments.php
+++ b/comments.php
@@ -26,7 +26,7 @@ if ( post_password_required() ) {
 		<h2 class="comments-title">
 			<?php
 				printf(
-					/* translators: %1$s: number of comments, %2$s: post title */
+					/* translators: 1: number of comments, 2: post title */
 					_nx(
 						'%1$s thought on &ldquo;%2$s&rdquo;',
 						'%1$s thoughts on &ldquo;%2$s&rdquo;',

--- a/comments.php
+++ b/comments.php
@@ -25,8 +25,17 @@ if ( post_password_required() ) {
 	<?php if ( have_comments() ) : ?>
 		<h2 class="comments-title">
 			<?php
-				printf( _nx( 'One thought on &ldquo;%2$s&rdquo;', '%1$s thoughts on &ldquo;%2$s&rdquo;', get_comments_number(), 'comments title', 'twentysixteen' ),
-					number_format_i18n( get_comments_number() ), get_the_title() );
+				printf(
+					_nx(
+						'%1$s thought on &ldquo;%2$s&rdquo;',
+						'%1$s thoughts on &ldquo;%2$s&rdquo;',
+						get_comments_number(),
+						'comments title',
+						'twentysixteen'
+					),
+					number_format_i18n( get_comments_number() ),
+					get_the_title()
+				);
 			?>
 		</h2>
 


### PR DESCRIPTION
Just like [stated over here](https://developer.wordpress.com/2015/04/23/wordpress-developers-test-your-i18n-internationalization-knowledge/), the `%d` placeholder should be included in both translation strings inside a `_n*()` call.
