### PR TITLE
Prevent irrelevant check.

### DIFF
--- a/singular.php
+++ b/singular.php
@@ -37,9 +37,7 @@ get_header(); ?>
 				the_post_navigation( array(
 					'prev_text' => _x( '<span class="meta-nav">Published in</span><span class="post-title">%title</span>', 'Parent post link', 'twentysixteen' ),
 				) );
-			}
-
-			if ( is_singular( 'post' ) ) {
+			} elseif ( is_singular( 'post' ) ) {
 				// Previous/next post navigation.
 				the_post_navigation( array(
 					'next_text' => '<span class="meta-nav" aria-hidden="true">' . __( 'Next', 'twentysixteen' ) . '</span> ' .


### PR DESCRIPTION
If the post is an attachment, we don't have to check if it's a post (which it's not).
