### PR TITLE
Improve selector for mailto links

### DIFF
--- a/style.css
+++ b/style.css
@@ -1000,7 +1000,7 @@ a:active {
 	content: "\f213";
 }
 
-.social-navigation a[href*="mailto:"]:before {
+.social-navigation a[href^="mailto:"]:before {
 	content: "\f410";
 }
 


### PR DESCRIPTION
`mailto:` links always **start** with `mailto:`, so let's improve the selector.
