### PR TITLE
Close main navigation dropdown menus on touchscreen

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -84,7 +84,6 @@
 					{
 						$( '.main-navigation li' ).removeClass( 'focus' ); 
 					}
-					$( '.main-navigation li' ).removeClass( 'focus' );			
 				} );
 
 				siteNavigation.find( '.menu-item-has-children > a' ).on( 'touchstart.twentysixteen', function( e ) {

--- a/js/functions.js
+++ b/js/functions.js
@@ -79,6 +79,14 @@
 		// Toggle `focus` class to allow submenu access on tablets.
 		function toggleFocusClassTouchScreen() {
 			if ( window.innerWidth > 910 ) {
+				$( 'body' ).on( 'touchstart.twentysixteen', function( ) {
+					if ( !$(event.target).closest('.main-navigation li').length )
+					{
+						$( '.main-navigation li' ).removeClass( 'focus' ); 
+					}
+					$( '.main-navigation li' ).removeClass( 'focus' );			
+				} );
+
 				siteNavigation.find( '.menu-item-has-children > a' ).on( 'touchstart.twentysixteen', function( e ) {
 					var el = $( this ).parent( 'li' );
 


### PR DESCRIPTION
This code allows a user on a touchscreen device (e.g. tablet) to tap anywhere else on the screen to close dropdown menus on the main navigation.
