### PR TITLE
Use Core Comments Navigation.

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -46,7 +46,7 @@ if ( post_password_required() ) {
 			?>
 		</h2>
 
-		<?php twentysixteen_comment_nav(); ?>
+		<?php the_comments_navigation(); ?>
 
 		<ol class="comment-list">
 			<?php
@@ -58,7 +58,7 @@ if ( post_password_required() ) {
 			?>
 		</ol><!-- .comment-list -->
 
-		<?php twentysixteen_comment_nav(); ?>
+		<?php the_comments_navigation(); ?>
 
 	<?php endif; // Check for have_comments(). ?>
 

--- a/functions.php
+++ b/functions.php
@@ -26,9 +26,9 @@
  */
 
 /**
- * Twenty Sixteen only works in WordPress 4.3 or later.
+ * Twenty Sixteen only works in WordPress 4.4 or later.
  */
-if ( version_compare( $GLOBALS['wp_version'], '4.3', '<' ) ) {
+if ( version_compare( $GLOBALS['wp_version'], '4.4-alpha', '<' ) ) {
 	require get_template_directory() . '/inc/back-compat.php';
 }
 

--- a/inc/back-compat.php
+++ b/inc/back-compat.php
@@ -1,10 +1,10 @@
 <?php
 /**
- * Twenty Sixteen back compat functionality
+ * Twenty Sixteen back compat functionality.
  *
- * Prevents Twenty Sixteen from running on WordPress versions prior to 4.3,
+ * Prevents Twenty Sixteen from running on WordPress versions prior to 4.4,
  * since this theme is not meant to be backward compatible beyond that and
- * relies on many newer functions and markup changes introduced in 4.3.
+ * relies on some newer functions and markup changes introduced in 4.4.
  *
  * @package WordPress
  * @subpackage Twenty_Sixteen
@@ -29,33 +29,33 @@ add_action( 'after_switch_theme', 'twentysixteen_switch_theme' );
  * Add message for unsuccessful theme switch.
  *
  * Prints an update nag after an unsuccessful attempt to switch to
- * Twenty Sixteen on WordPress versions prior to 4.3.
+ * Twenty Sixteen on WordPress versions prior to 4.4.
  *
  * @since Twenty Sixteen 1.0
  *
  * @global string $wp_version
  */
 function twentysixteen_upgrade_notice() {
-	$message = sprintf( __( 'Twenty Sixteen requires at least WordPress version 4.3. You are running version %s. Please upgrade and try again.', 'twentysixteen' ), $GLOBALS['wp_version'] );
+	$message = sprintf( __( 'Twenty Sixteen requires at least WordPress version 4.4. You are running version %s. Please upgrade and try again.', 'twentysixteen' ), $GLOBALS['wp_version'] );
 	printf( '<div class="error"><p>%s</p></div>', $message );
 }
 
 /**
- * Prevent the Customizer from being loaded on WordPress versions prior to 4.3.
+ * Prevent the Customizer from being loaded on WordPress versions prior to 4.4.
  *
  * @since Twenty Sixteen 1.0
  *
  * @global string $wp_version
  */
 function twentysixteen_customize() {
-	wp_die( sprintf( __( 'Twenty Sixteen requires at least WordPress version 4.3. You are running version %s. Please upgrade and try again.', 'twentysixteen' ), $GLOBALS['wp_version'] ), '', array(
+	wp_die( sprintf( __( 'Twenty Sixteen requires at least WordPress version 4.4. You are running version %s. Please upgrade and try again.', 'twentysixteen' ), $GLOBALS['wp_version'] ), '', array(
 		'back_link' => true,
 	) );
 }
 add_action( 'load-customize.php', 'twentysixteen_customize' );
 
 /**
- * Prevent the Theme Preview from being loaded on WordPress versions prior to 4.3.
+ * Prevent the Theme Preview from being loaded on WordPress versions prior to 4.4.
  *
  * @since Twenty Sixteen 1.0
  *
@@ -63,7 +63,7 @@ add_action( 'load-customize.php', 'twentysixteen_customize' );
  */
 function twentysixteen_preview() {
 	if ( isset( $_GET['preview'] ) ) {
-		wp_die( sprintf( __( 'Twenty Sixteen requires at least WordPress version 4.3. You are running version %s. Please upgrade and try again.', 'twentysixteen' ), $GLOBALS['wp_version'] ) );
+		wp_die( sprintf( __( 'Twenty Sixteen requires at least WordPress version 4.4. You are running version %s. Please upgrade and try again.', 'twentysixteen' ), $GLOBALS['wp_version'] ) );
 	}
 }
 add_action( 'template_redirect', 'twentysixteen_preview' );

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -9,35 +9,6 @@
  * @since Twenty Sixteen 1.0
  */
 
-if ( ! function_exists( 'twentysixteen_comment_nav' ) ) :
-/**
- * Display navigation to next/previous comments when applicable.
- *
- * @since Twenty Sixteen 1.0
- */
-function twentysixteen_comment_nav() {
-	// Are there comments to navigate through?
-	if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) :
-	?>
-	<nav class="navigation comment-navigation" role="navigation">
-		<h2 class="screen-reader-text"><?php _e( 'Comment navigation', 'twentysixteen' ); ?></h2>
-		<div class="nav-links">
-			<?php
-				if ( $prev_link = get_previous_comments_link( __( 'Older Comments', 'twentysixteen' ) ) ) {
-					printf( '<div class="nav-previous">%s</div>', $prev_link );
-				}
-
-				if ( $next_link = get_next_comments_link( __( 'Newer Comments', 'twentysixteen' ) ) ) {
-					printf( '<div class="nav-next">%s</div>', $next_link );
-				}
-			?>
-		</div><!-- .nav-links -->
-	</nav><!-- .comment-navigation -->
-	<?php
-	endif;
-}
-endif;
-
 if ( ! function_exists( 'twentysixteen_entry_meta' ) ) :
 /**
  * Prints HTML with meta information for the categories, tags.

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Twenty Sixteen ===
 Contributors: the WordPress team
-Requires at least: WordPress 4.3
+Requires at least: WordPress 4.4
 Tested up to: WordPress 4.4-trunk
 Version: 1.0
 License: GPLv2 or later


### PR DESCRIPTION
Refresh of #237.

https://core.trac.wordpress.org/changeset/34367 finally introduced themissing comments navigation template tags. Let’s use those.

**Also bumps the minimum required version to 4.4-alpha.**
