### PR TITLE
Make dropdown of the last item to go to the left

### DIFF
--- a/rtl.css
+++ b/rtl.css
@@ -530,12 +530,6 @@ body:not(.search-results) .entry-summary .alignleft {
 		right: -999em;
 	}
 
-	.main-navigation ul ul li:hover > ul,
-	.main-navigation ul ul li.focus > ul {
-		left: auto;
-		right: 100%;
-	}
-
 	.main-navigation ul ul:before {
 		left: auto;
 		right: 7px;
@@ -546,8 +540,36 @@ body:not(.search-results) .entry-summary .alignleft {
 		right: 9px;
 	}
 
+	.main-navigation .primary-menu > li:last-child ul:before {
+		left: 7px;
+		right: auto;
+	}
+
+	.main-navigation .primary-menu > li:last-child ul:after {
+		left: 9px;
+		right: auto;
+	}
+
 	.main-navigation li:hover > ul,
 	.main-navigation li.focus > ul {
+		right: auto;
+	}
+
+	.main-navigation .primary-menu > li:last-child:hover > ul,
+	.main-navigation .primary-menu > li:last-child.focus > ul {
+		left: 0;
+		right: auto;
+	}
+
+	.main-navigation ul ul li:hover > ul,
+	.main-navigation ul ul li.focus > ul {
+		left: auto;
+		right: 100%;
+	}
+
+	.main-navigation .primary-menu > li:last-child ul li:hover > ul,
+	.main-navigation .primary-menu > li:last-child ul li.focus > ul {
+		left: 100%;
 		right: auto;
 	}
 
@@ -571,9 +593,17 @@ body:not(.search-results) .entry-summary .alignleft {
 		left: 0.5625em;
 		right: auto;
 		-webkit-transform: rotate(90deg);
-    	-moz-transform: rotate(90deg);
-    	-ms-transform: rotate(90deg);
-    	transform: rotate(90deg);
+		-moz-transform: rotate(90deg);
+		-ms-transform: rotate(90deg);
+		transform: rotate(90deg);
+	}
+
+	.main-navigation .primary-menu > li:last-child ul .menu-item-has-children > a:after {
+		top: 0.8125em;
+		-webkit-transform: rotate(-90deg);
+		-moz-transform: rotate(-90deg);
+		-ms-transform: rotate(-90deg);
+		transform: rotate(-90deg);
 	}
 
 	.content-area {

--- a/style.css
+++ b/style.css
@@ -2962,11 +2962,6 @@ p > video {
 		border-bottom-width: 0;
 	}
 
-	.main-navigation ul ul li:hover > ul,
-	.main-navigation ul ul li.focus > ul {
-		left: 100%;
-	}
-
 	.main-navigation ul ul a {
 		white-space: normal;
 		width: 15em;
@@ -2986,6 +2981,16 @@ p > video {
 		top: -9px;
 	}
 
+	.main-navigation .primary-menu > li:last-child ul:before {
+		left: auto;
+		right: 9px;
+	}
+
+	.main-navigation .primary-menu > li:last-child ul:after {
+		left: auto;
+		right: 11px;
+	}
+
 	.main-navigation ul ul:after {
 		border-color: #fff transparent;
 		border-width: 0 8px 8px;
@@ -2996,6 +3001,22 @@ p > video {
 	.main-navigation li:hover > ul,
 	.main-navigation li.focus > ul {
 		left: auto;
+	}
+
+	.main-navigation .primary-menu > li:last-child:hover > ul,
+	.main-navigation .primary-menu > li:last-child.focus > ul {
+		right: 0;
+	}
+
+	.main-navigation ul ul li:hover > ul,
+	.main-navigation ul ul li.focus > ul {
+		left: 100%;
+	}
+
+	.main-navigation .primary-menu > li:last-child ul li:hover > ul,
+	.main-navigation .primary-menu > li:last-child ul li.focus > ul {
+		left: auto;
+		right: 100%;
 	}
 
 	.main-navigation .menu-item-has-children > a {
@@ -3021,6 +3042,14 @@ p > video {
 		-moz-transform: rotate(-90deg);
 		-ms-transform: rotate(-90deg);
 		transform: rotate(-90deg);
+	}
+
+	.main-navigation .primary-menu > li:last-child ul .menu-item-has-children > a:after {
+		top: 0.875em;
+		-webkit-transform: rotate(90deg);
+		-moz-transform: rotate(90deg);
+		-ms-transform: rotate(90deg);
+		transform: rotate(90deg);
 	}
 
 	.dropdown-toggle,


### PR DESCRIPTION
Since the theme has right aligned menu, often times the dropdown overflows out of page. This issue has been pointed out in #112, #123, and #321 but it's been "wontfix" because we haven't seen a perfect solution for it. 

Although this is far from the perfect solution which works in any case, we can avoid the overflow in likely scenarios — with not too many menu items.

![screen shot 2015-10-01 at 23 59 09](https://cloud.githubusercontent.com/assets/908665/10236536/8fd62dd8-689e-11e5-8f28-c4d815e50894.png)
