### PR TITLE
Use Core Comments Navigation.

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -46,7 +46,7 @@ if ( post_password_required() ) {
 			?>
 		</h2>
 
-		<?php twentysixteen_comment_nav(); ?>
+		<?php the_comments_navigation(); ?>
 
 		<ol class="comment-list">
 			<?php
@@ -58,7 +58,7 @@ if ( post_password_required() ) {
 			?>
 		</ol><!-- .comment-list -->
 
-		<?php twentysixteen_comment_nav(); ?>
+		<?php the_comments_navigation(); ?>
 
 	<?php endif; // Check for have_comments(). ?>
 

--- a/functions.php
+++ b/functions.php
@@ -26,9 +26,9 @@
  */
 
 /**
- * Twenty Sixteen only works in WordPress 4.3 or later.
+ * Twenty Sixteen only works in WordPress 4.4 or later.
  */
-if ( version_compare( $GLOBALS['wp_version'], '4.3', '<' ) ) {
+if ( version_compare( $GLOBALS['wp_version'], '4.4-alpha', '<' ) ) {
 	require get_template_directory() . '/inc/back-compat.php';
 }
 

--- a/inc/back-compat.php
+++ b/inc/back-compat.php
@@ -2,9 +2,9 @@
 /**
  * Twenty Sixteen back compat functionality
  *
- * Prevents Twenty Sixteen from running on WordPress versions prior to 4.3,
+ * Prevents Twenty Sixteen from running on WordPress versions prior to 4.4,
  * since this theme is not meant to be backward compatible beyond that and
- * relies on many newer functions and markup changes introduced in 4.3.
+ * relies on many newer functions and markup changes introduced in 4.4.
  *
  * @package WordPress
  * @subpackage Twenty_Sixteen
@@ -31,33 +31,33 @@ add_action( 'after_switch_theme', 'twentysixteen_switch_theme' );
  * Adds a message for unsuccessful theme switch.
  *
  * Prints an update nag after an unsuccessful attempt to switch to
- * Twenty Sixteen on WordPress versions prior to 4.3.
+ * Twenty Sixteen on WordPress versions prior to 4.4.
  *
  * @since Twenty Sixteen 1.0
  *
  * @global string $wp_version WordPress version.
  */
 function twentysixteen_upgrade_notice() {
-	$message = sprintf( __( 'Twenty Sixteen requires at least WordPress version 4.3. You are running version %s. Please upgrade and try again.', 'twentysixteen' ), $GLOBALS['wp_version'] );
+	$message = sprintf( __( 'Twenty Sixteen requires at least WordPress version 4.4. You are running version %s. Please upgrade and try again.', 'twentysixteen' ), $GLOBALS['wp_version'] );
 	printf( '<div class="error"><p>%s</p></div>', $message );
 }
 
 /**
- * Prevents the Customizer from being loaded on WordPress versions prior to 4.3.
+ * Prevents the Customizer from being loaded on WordPress versions prior to 4.4.
  *
  * @since Twenty Sixteen 1.0
  *
  * @global string $wp_version WordPress version.
  */
 function twentysixteen_customize() {
-	wp_die( sprintf( __( 'Twenty Sixteen requires at least WordPress version 4.3. You are running version %s. Please upgrade and try again.', 'twentysixteen' ), $GLOBALS['wp_version'] ), '', array(
+	wp_die( sprintf( __( 'Twenty Sixteen requires at least WordPress version 4.4. You are running version %s. Please upgrade and try again.', 'twentysixteen' ), $GLOBALS['wp_version'] ), '', array(
 		'back_link' => true,
 	) );
 }
 add_action( 'load-customize.php', 'twentysixteen_customize' );
 
 /**
- * Prevents the Theme Preview from being loaded on WordPress versions prior to 4.3.
+ * Prevents the Theme Preview from being loaded on WordPress versions prior to 4.4.
  *
  * @since Twenty Sixteen 1.0
  *
@@ -65,7 +65,7 @@ add_action( 'load-customize.php', 'twentysixteen_customize' );
  */
 function twentysixteen_preview() {
 	if ( isset( $_GET['preview'] ) ) {
-		wp_die( sprintf( __( 'Twenty Sixteen requires at least WordPress version 4.3. You are running version %s. Please upgrade and try again.', 'twentysixteen' ), $GLOBALS['wp_version'] ) );
+		wp_die( sprintf( __( 'Twenty Sixteen requires at least WordPress version 4.4. You are running version %s. Please upgrade and try again.', 'twentysixteen' ), $GLOBALS['wp_version'] ) );
 	}
 }
 add_action( 'template_redirect', 'twentysixteen_preview' );

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -9,37 +9,6 @@
  * @since Twenty Sixteen 1.0
  */
 
-if ( ! function_exists( 'twentysixteen_comment_nav' ) ) :
-/**
- * Displays navigation to next/previous comments when applicable.
- *
- * Create your own twentysixteen_comment_nav() function to override in a child theme.
- *
- * @since Twenty Sixteen 1.0
- */
-function twentysixteen_comment_nav() {
-	// Determin if there are comments to navigate through.
-	if ( get_comment_pages_count() > 1 && get_option( 'page_comments' ) ) :
-	?>
-	<nav class="navigation comment-navigation" role="navigation">
-		<h2 class="screen-reader-text"><?php _e( 'Comment navigation', 'twentysixteen' ); ?></h2>
-		<div class="nav-links">
-			<?php
-				if ( $prev_link = get_previous_comments_link( __( 'Older Comments', 'twentysixteen' ) ) ) {
-					printf( '<div class="nav-previous">%s</div>', $prev_link );
-				}
-
-				if ( $next_link = get_next_comments_link( __( 'Newer Comments', 'twentysixteen' ) ) ) {
-					printf( '<div class="nav-next">%s</div>', $next_link );
-				}
-			?>
-		</div><!-- .nav-links -->
-	</nav><!-- .comment-navigation -->
-	<?php
-	endif;
-}
-endif;
-
 if ( ! function_exists( 'twentysixteen_entry_meta' ) ) :
 /**
  * Prints HTML with meta information for the categories, tags.

--- a/languages/twentysixteen.pot
+++ b/languages/twentysixteen.pot
@@ -152,7 +152,7 @@ msgstr ""
 
 #: inc/back-compat.php:37 inc/back-compat.php:47 inc/back-compat.php:60
 msgid ""
-"Twenty Sixteen requires at least WordPress version 4.3. You are running "
+"Twenty Sixteen requires at least WordPress version 4.4. You are running "
 "version %s. Please upgrade and try again."
 msgstr ""
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Twenty Sixteen ===
 Contributors: the WordPress team
-Requires at least: WordPress 4.3
-Tested up to: WordPress 4.4-trunk
+Requires at least: WordPress 4.4
+Tested up to: WordPress 4.4
 Version: 1.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html


### PR DESCRIPTION
Refresh of #317.

https://core.trac.wordpress.org/changeset/34367 finally introduced themissing comments navigation template tags. Let’s use those.

**Also bumps the minimum required version to 4.4-alpha.**
