### PR TITLE
Changed input bg's from solid gray to faded white

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -46,7 +46,11 @@ if ( post_password_required() ) {
 			?>
 		</h2>
 
-		<?php the_comments_navigation(); ?>
+		<?php
+			if (function_exists('the_comments_navigation')) {
+				the_comments_navigation();
+			}
+		?>
 
 		<ol class="comment-list">
 			<?php
@@ -58,7 +62,11 @@ if ( post_password_required() ) {
 			?>
 		</ol><!-- .comment-list -->
 
-		<?php the_comments_navigation(); ?>
+		<?php
+			if (function_exists('the_comments_navigation')) {
+				the_comments_navigation();
+			}
+		?>
 
 	<?php endif; // Check for have_comments(). ?>
 

--- a/style.css
+++ b/style.css
@@ -620,7 +620,7 @@ input[type="search"],
 input[type="tel"],
 input[type="number"],
 textarea {
-	background: #f7f7f7;
+	background: rgba(255,255,255,0.5);
 	background-image: -webkit-linear-gradient(rgba(255, 255, 255, 0), rgba(255, 255, 255, 0));
 	border: 1px solid #d1d1d1;
 	border-radius: 2px;


### PR DESCRIPTION
When changing the page background color, I noticed that the search box in the sidebar widget was staying the gray #f7f7f7 color. With black or white backgrounds it was ok, but when you started using yellow or other color variations, the gray really clashed.

I believe this fixes the problem and allows the input fields to blend better with the theme, no matter what color the user selects.
