### PR TITLE
Vendor Prefixes for box-sizing

### DIFF
--- a/style.css
+++ b/style.css
@@ -148,6 +148,8 @@ figure {
 
 hr {
 	box-sizing: content-box;
+	-webkit-box-sizing: content-box;
+  	-moz-box-sizing: content-box;
 }
 
 code,
@@ -205,6 +207,8 @@ input::-moz-focus-inner {
 input[type="checkbox"],
 input[type="radio"] {
 	box-sizing: border-box;
+	-webkit-box-sizing: border-box;
+  	-moz-box-sizing: border-box;
 	margin-right: 0.4375em;
 	padding: 0;
 }
@@ -435,6 +439,8 @@ big {
 
 html {
 	box-sizing: border-box;
+	-webkit-box-sizing: border-box;
+  	-moz-box-sizing: border-box;
 }
 
 *,
@@ -442,6 +448,8 @@ html {
 *:after {
 	/* Inherit box-sizing to make it easier to change the property for components that leverage other behavior; see http://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/ */
 	box-sizing: inherit;
+	-webkit-box-sizing: inherit;
+  	-moz-box-sizing: inherit;
 }
 
 body {


### PR DESCRIPTION
To support older versions of Safari (< 5.1), Chrome (< 10), and Firefox (< 29), one should include the prefixes -webkit and -moz.
