### PR TITLE
Adding check for the comments navigation #331

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -46,7 +46,11 @@ if ( post_password_required() ) {
 			?>
 		</h2>
 
-		<?php the_comments_navigation(); ?>
+		<?php
+			if (function_exists('the_comments_navigation')) {
+				the_comments_navigation();
+			}
+		?>
 
 		<ol class="comment-list">
 			<?php
@@ -58,7 +62,11 @@ if ( post_password_required() ) {
 			?>
 		</ol><!-- .comment-list -->
 
-		<?php the_comments_navigation(); ?>
+		<?php
+			if (function_exists('the_comments_navigation')) {
+				the_comments_navigation();
+			}
+		?>
 
 	<?php endif; // Check for have_comments(). ?>
 

--- a/comments.php
+++ b/comments.php
@@ -47,7 +47,7 @@ if ( post_password_required() ) {
 		</h2>
 
 		<?php
-			if (function_exists('the_comments_navigation')) {
+			if ( function_exists( 'the_comments_navigation' ) ) {
 				the_comments_navigation();
 			}
 		?>
@@ -63,7 +63,7 @@ if ( post_password_required() ) {
 		</ol><!-- .comment-list -->
 
 		<?php
-			if (function_exists('the_comments_navigation')) {
+			if ( function_exists( 'the_comments_navigation' ) ) {
 				the_comments_navigation();
 			}
 		?>


### PR DESCRIPTION
Versions of WordPress before 4.4 don't have `the_comments_function()` built in and throw errors, breaking the theme on the screen. I added a `function_exists` check to ensure that it doesn't run if the users version of WordPress is older than 4.4
