### PR TITLE
Search Widget box-sizing added

### DIFF
--- a/style.css
+++ b/style.css
@@ -3212,6 +3212,9 @@ p > video {
 
 	.widget input[type="search"].search-field {
 		padding-right: 42px;
+		box-sizing: border-box;
+		-webkit-box-sizing: border-box;
+		-moz-box-sizing: border-box;
 	}
 
 	.widget .search-submit:before {


### PR DESCRIPTION
Search widget needs to keep the `box-sizing: border-box` to keep itself contained. 

I am using Macbook Pro 15.6" 2014 with latest Chrome. 

**Before**
Here is the before image `box-sizing`
![before](https://i.imgur.com/ZfSKVQU.png)

**After**
After adding `box-sizing`
![after](https://i.imgur.com/cMTIAiD.png)
