### PR TITLE
Better Flexbox Fallback Support for Legacy Methods

### DIFF
--- a/style.css
+++ b/style.css
@@ -770,6 +770,8 @@ a:active {
 
 .site-header-menu {
 	display: none;
+	-webkit-box-flex: 0 1 100%;
+	-moz-box-flex: 0 1 100%;
 	-webkit-flex: 0 1 100%;
 	-ms-flex: 0 1 100%;
 	flex: 0 1 100%;
@@ -1544,6 +1546,8 @@ blockquote:after,
 	-webkit-align-items: center;
 	-ms-flex-align: center;
 	align-items: center;
+	display: -webkit-box;
+  	display: -moz-box;
 	display: -webkit-flex;
 	display: -ms-flexbox;
 	display: flex;
@@ -3279,6 +3283,8 @@ p > video {
 		-webkit-align-items: center;
 		-ms-flex-align: center;
 		align-items: center;
+		display: -webkit-box;
+  		display: -moz-box;
 		display: -webkit-flex;
 		display: -ms-flexbox;
 		display: flex;


### PR DESCRIPTION
As recommended by https://css-tricks.com/snippets/css/a-guide-to-flexbox/ I have added a few fallbacks to flex usage to cover the old syntax from 2009.
