### PR TITLE
Make dropdown go to the left to avoid oveflowing

### DIFF
--- a/rtl.css
+++ b/rtl.css
@@ -529,29 +529,25 @@ body:not(.search-results) .entry-summary .alignleft {
 		right: -999em;
 	}
 
-	.main-navigation ul ul ul {
-		left: auto;
-		right: -999em;
-	}
-
-	.main-navigation ul ul li:hover > ul,
-	.main-navigation ul ul li.focus > ul {
-		left: auto;
-		right: 100%;
-	}
-
 	.main-navigation ul ul:before {
-		left: auto;
-		right: 7px;
+		left: 9px;
+		right: auto;
 	}
 
 	.main-navigation ul ul:after {
-		left: auto;
-		right: 9px;
+		left: 11px;
+		right: auto;
 	}
 
 	.main-navigation li:hover > ul,
 	.main-navigation li.focus > ul {
+		left: 0;
+		right: auto;
+	}
+
+	.main-navigation ul ul li:hover > ul,
+	.main-navigation ul ul li.focus > ul {
+		left: 100%;
 		right: auto;
 	}
 
@@ -574,10 +570,11 @@ body:not(.search-results) .entry-summary .alignleft {
 	.main-navigation ul ul .menu-item-has-children > a:after {
 		left: 0.5625em;
 		right: auto;
-		-webkit-transform: rotate(90deg);
-		-moz-transform: rotate(90deg);
-		-ms-transform: rotate(90deg);
-		transform: rotate(90deg);
+		top: 0.8125em;
+		-webkit-transform: rotate(-90deg);
+		-moz-transform: rotate(-90deg);
+		-ms-transform: rotate(-90deg);
+		transform: rotate(-90deg);
 	}
 
 	.content-area {

--- a/style.css
+++ b/style.css
@@ -2958,7 +2958,6 @@ p > video {
 	}
 
 	.main-navigation ul ul ul {
-		left: -999em;
 		top: -1px;
 	}
 
@@ -2973,14 +2972,9 @@ p > video {
 		border-bottom-width: 0;
 	}
 
-	.main-navigation ul ul li:hover > ul,
-	.main-navigation ul ul li.focus > ul {
-		left: 100%;
-	}
-
 	.main-navigation ul ul a {
 		white-space: normal;
-		width: 15em;
+		width: 12.6875em;
 	}
 
 	.main-navigation ul ul:before,
@@ -2993,20 +2987,27 @@ p > video {
 	.main-navigation ul ul:before {
 		border-color: #d1d1d1 transparent;
 		border-width: 0 10px 10px;
-		left: 7px;
+		right: 9px;
 		top: -9px;
 	}
 
 	.main-navigation ul ul:after {
 		border-color: #fff transparent;
 		border-width: 0 8px 8px;
-		left: 9px;
+		right: 11px;
 		top: -7px;
 	}
 
 	.main-navigation li:hover > ul,
 	.main-navigation li.focus > ul {
 		left: auto;
+		right: 0;
+	}
+
+	.main-navigation ul ul li:hover > ul,
+	.main-navigation ul ul li.focus > ul {
+		left: auto;
+		right: 100%;
 	}
 
 	.main-navigation .menu-item-has-children > a {
@@ -3027,11 +3028,11 @@ p > video {
 
 	.main-navigation ul ul .menu-item-has-children > a:after {
 		right: 0.5625em;
-		top: 0.8125em;
-		-webkit-transform: rotate(-90deg);
-		-moz-transform: rotate(-90deg);
-		-ms-transform: rotate(-90deg);
-		transform: rotate(-90deg);
+		top: 0.875em;
+		-webkit-transform: rotate(90deg);
+		-moz-transform: rotate(90deg);
+		-ms-transform: rotate(90deg);
+		transform: rotate(90deg);
 	}
 
 	.dropdown-toggle,


### PR DESCRIPTION
Since the theme has right aligned menu, often times the dropdown overflows out of page. This issue has been pointed out in #112, #123, and #321 but it's been "wontfixed" as a design limitation.

I must admit it feels a bit weird and it's not the perfect solution as if the navigation having many items drops below the site title, then we have the same issue but other way around.

However, the most likely scenario is the menu being on the right, and in this way, we can avoid the overflowing in the majority of cases.

![screen shot 2015-10-07 at 03 12 11](https://cloud.githubusercontent.com/assets/908665/10327618/3dbf7d2c-6ca1-11e5-8232-ac1d2c2d12f4.png)
