### PR TITLE
Improving responsive image support - update

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -31,3 +31,4 @@
 @obenland
 @cainm
 @mrahmadawais
+@tevko

--- a/functions.php
+++ b/functions.php
@@ -72,13 +72,6 @@ function twentysixteen_setup() {
 	add_theme_support( 'post-thumbnails' );
 	set_post_thumbnail_size( 1200, 0, true );
 
-	/*
-	 * Add image size to enhance responsive image functionality
-	 *
-	 * @link https://developer.wordpress.org/reference/functions/add_image_size/
-	 */
-	add_image_size( 'twentysixteen-intermediate-width', 600, 600 );
-
 	// This theme uses wp_nav_menu() in two locations.
 	register_nav_menus( array(
 		'primary' => __( 'Primary Menu', 'twentysixteen' ),
@@ -358,7 +351,7 @@ require get_template_directory() . '/inc/customizer.php';
  */
 function twentysixteen_image_sizes_attr( $sizes, $id, $size ) {
 	if ( 'large' === $size ) {
-		$sizes = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1361px) 44vw, 600px';
+		$sizes = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1362px) 44vw, 600px';
 	} elseif ( 'full' === $size || 'post-thumbnail' === $size ) {
 		$sizes = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1362px) 62vw, 840px';
 	}

--- a/functions.php
+++ b/functions.php
@@ -350,17 +350,18 @@ require get_template_directory() . '/inc/customizer.php';
  *
  * @since Twenty Sixteen 1.0
  *
- * @param array  $args An array of arguments used to create a 'sizes' attribute.
- * @param int    $id Post ID of the original image.
- * @param string $size Name of the image size being used.
- * @return string A sizes attribute to be used on an image with a srcset attribute
+ * @param string       $sizes A source size value for use in a 'sizes' attribute.
+ * @param int          $id    Post ID of the original image.
+ * @param array|string $size  Image size. Accepts any valid image size, or an array of width and
+ *                            height values in pixels (in that order). Default 'medium'.
+ * @return string A source size value for use in a 'sizes' attribute.
  */
-function twentysixteen_image_sizes_attr( $args, $id, $size ) {
-	if ( 'large' == $size ) {
-		$args['sizes'] = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1361px) 44vw, 600px';
-	} elseif ( 'full' == $size || 'post-thumbnail' == $size ) {
-		$args['sizes'] = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1362px) 62vw, 840px';
+function twentysixteen_image_sizes_attr( $sizes, $id, $size ) {
+	if ( 'large' === $size ) {
+		$sizes = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1361px) 44vw, 600px';
+	} elseif ( 'full' === $size || 'post-thumbnail' === $size ) {
+		$sizes = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1362px) 62vw, 840px';
 	}
-	return $args;
+	return $sizes;
 }
-add_filter( 'wp_image_sizes_args', 'twentysixteen_image_sizes_attr', 10 , 3 );
+add_filter( 'wp_get_attachment_image_sizes', 'twentysixteen_image_sizes_attr', 10 , 3 );

--- a/functions.php
+++ b/functions.php
@@ -352,7 +352,7 @@ require get_template_directory() . '/inc/customizer.php';
 function twentysixteen_content_image_sizes_attr( $sizes, $size ) {
 	$width = $size[0];
 	if ( 'page' === get_post_type() ) {
-		840 <= $width && $sizes = '(max-width: 709px) 85vw, (max-width: 909px) 60vw, (max-width: 1379px) 62vw, 840px';
+		840 <= $width && $sizes = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 1362px) 62vw, 840px';
 		840 >= $width && $sizes = '(max-width: ' . $width . 'px) 85vw, ' . $width . 'px';
 	} else {
 		600 <= $width && $sizes = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1362px) 44vw, 600px';
@@ -360,7 +360,7 @@ function twentysixteen_content_image_sizes_attr( $sizes, $size ) {
 	}
 	return $sizes;
 }
-add_filter( 'wp_get_attachment_image_sizes', 'twentysixteen_content_image_sizes_attr', 10 , 2 );
+add_filter( 'wp_calculate_image_sizes', 'twentysixteen_content_image_sizes_attr', 10 , 2 );
 
 /**
  * Add custom image sizes attribute to enhance responsive image functionality

--- a/functions.php
+++ b/functions.php
@@ -77,7 +77,7 @@ function twentysixteen_setup() {
 	 *
 	 * @link https://developer.wordpress.org/reference/functions/add_image_size/
 	 */
-	add_image_size( 'intermediate-width', 600, 600 );
+	add_image_size( 'twentysixteen-intermediate-width', 600, 600 );
 
 	// This theme uses wp_nav_menu() in two locations.
 	register_nav_menus( array(
@@ -357,9 +357,9 @@ require get_template_directory() . '/inc/customizer.php';
  */
 function twentysixteen_image_sizes_attr( $args, $id, $size ) {
 	if ( 'large' == $size ) {
-		$args['sizes'] = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1319px) 44vw, 600px';
+		$args['sizes'] = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1361px) 44vw, 600px';
 	} elseif ( 'full' == $size || 'post-thumbnail' == $size ) {
-		$args['sizes'] = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1379px) 62vw, 840px';
+		$args['sizes'] = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1362px) 62vw, 840px';
 	}
 	return $args;
 }

--- a/functions.php
+++ b/functions.php
@@ -367,14 +367,14 @@ add_filter( 'wp_get_attachment_image_sizes', 'twentysixteen_content_image_sizes_
  * @since Twenty Sixteen 1.0
  *
  * @param array $attr Attributes for the image markup.
- * @param int  $attachment Image attachment ID.
+ * @param int   $attachment Image attachment ID.
  * @param array $size Registered image size or flat array of height and width dimensions.
  * @return string A source size value for use in a post thumbnail 'sizes' attribute.
  */
 function twentysixteen_post_thumbnail_sizes_attr( $attr, $attachment, $size ) {
 	if ( 'post-thumbnail' === $size ) {
 		is_active_sidebar( 'sidebar-1' ) && $attr['sizes'] = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1362px) 62vw, 840px';
-		false === is_active_sidebar( 'sidebar-1' ) && $attr['sizes'] = '(max-width: 709px) 85vw, (max-width: 909px) 65vw, (max-width: 1362px) 88vw, 1200px';
+		is_active_sidebar( 'sidebar-1' ) === false && $attr['sizes'] = '(max-width: 709px) 85vw, (max-width: 909px) 65vw, (max-width: 1362px) 88vw, 1200px';
 	}
 	return $attr;
 }

--- a/functions.php
+++ b/functions.php
@@ -345,11 +345,6 @@ require get_template_directory() . '/inc/template-tags.php';
  */
 require get_template_directory() . '/inc/customizer.php';
 
-/*
- *
- *
- * @link https://core.trac.wordpress.org/browser/trunk/src/wp-includes/media.php#L1035
- */
 /**
  * Add custom image sizes attribute to enhance responsive image functionality
  *

--- a/functions.php
+++ b/functions.php
@@ -355,8 +355,8 @@ require get_template_directory() . '/inc/customizer.php';
  *
  * @since Twenty Sixteen 1.0
  *
- * @param array $args An array of arguments used to create a 'sizes' attribute.
- * @param int $attachment_id Post ID of the original image.
+ * @param array  $args An array of arguments used to create a 'sizes' attribute.
+ * @param int    $id Post ID of the original image.
  * @param string $size Name of the image size being used.
  * @return string A sizes attribute to be used on an image with a srcset attribute
  */

--- a/functions.php
+++ b/functions.php
@@ -340,21 +340,42 @@ require get_template_directory() . '/inc/customizer.php';
 
 /**
  * Add custom image sizes attribute to enhance responsive image functionality
+ * for content images
  *
  * @since Twenty Sixteen 1.0
  *
  * @param string       $sizes A source size value for use in a 'sizes' attribute.
- * @param int          $id    Post ID of the original image.
- * @param array|string $size  Image size. Accepts any valid image size, or an array of width and
- *                            height values in pixels (in that order). Default 'medium'.
- * @return string A source size value for use in a 'sizes' attribute.
+ * @param array        $size  Image size. Accepts an array of width and height
+ *                            values in pixels (in that order).
+ * @return string A source size value for use in a content image 'sizes' attribute.
  */
-function twentysixteen_image_sizes_attr( $sizes, $id, $size ) {
-	if ( 'large' === $size ) {
-		$sizes = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1362px) 44vw, 600px';
-	} elseif ( 'full' === $size || 'post-thumbnail' === $size ) {
-		$sizes = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1362px) 62vw, 840px';
+function twentysixteen_content_image_sizes_attr( $sizes, $size ) {
+	$width = $size[0];
+	if ( 'page' === get_post_type() ) {
+		840 <= $width && $sizes = '(max-width: 709px) 85vw, (max-width: 909px) 60vw, (max-width: 1379px) 62vw, 840px';
+	} else {
+		600 <= $width && $sizes = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1362px) 44vw, 600px';
 	}
 	return $sizes;
 }
-add_filter( 'wp_get_attachment_image_sizes', 'twentysixteen_image_sizes_attr', 10 , 3 );
+add_filter( 'wp_get_attachment_image_sizes', 'twentysixteen_content_image_sizes_attr', 10 , 2 );
+
+/**
+ * Add custom image sizes attribute to enhance responsive image functionality
+ * for post thumbnails
+ *
+ * @since Twenty Sixteen 1.0
+ *
+ * @param string       $sizes A source size value for use in a 'sizes' attribute.
+ * @param array        $size  Image size. Accepts an array of width and height
+ *                            values in pixels (in that order).
+ * @return string A source size value for use in a post thumbnail 'sizes' attribute.
+ */
+function twentysixteen_post_thumbnail_sizes_attr( $attr, $attachment, $size ) {
+	if ( $size === 'post-thumbnail' ) {
+		is_active_sidebar( 'sidebar-1' ) && $attr['sizes'] = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1362px) 62vw, 840px';
+		false === is_active_sidebar( 'sidebar-1' ) && $attr['sizes'] = '(max-width: 709px) 85vw, (max-width: 909px) 65vw, (max-width: 1362px) 88vw, 1200px';
+	}
+	return $attr;
+}
+add_filter( 'wp_get_attachment_image_attributes', 'twentysixteen_post_thumbnail_sizes_attr', 10 , 3 );

--- a/functions.php
+++ b/functions.php
@@ -353,8 +353,10 @@ function twentysixteen_content_image_sizes_attr( $sizes, $size ) {
 	$width = $size[0];
 	if ( 'page' === get_post_type() ) {
 		840 <= $width && $sizes = '(max-width: 709px) 85vw, (max-width: 909px) 60vw, (max-width: 1379px) 62vw, 840px';
+		840 >= $width && $sizes = '(max-width: ' . $width . 'px) 85vw, ' . $width . 'px';
 	} else {
 		600 <= $width && $sizes = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1362px) 44vw, 600px';
+		600 >= $width && $sizes = '(max-width: ' . $width . 'px) 85vw, ' . $width . 'px';
 	}
 	return $sizes;
 }

--- a/functions.php
+++ b/functions.php
@@ -239,32 +239,32 @@ function twentysixteen_scripts() {
 	wp_enqueue_style( 'twentysixteen-style', get_stylesheet_uri() );
 
 	// Load the Internet Explorer specific stylesheet.
-	wp_enqueue_style( 'twentysixteen-ie', get_template_directory_uri() . '/css/ie.css', array( 'twentysixteen-style' ), '20150825' );
+	wp_enqueue_style( 'twentysixteen-ie', get_template_directory_uri() . '/css/ie.css', array( 'twentysixteen-style' ), '20151007' );
 	wp_style_add_data( 'twentysixteen-ie', 'conditional', 'lt IE 10' );
 
 	// Load the Internet Explorer 8 specific stylesheet.
-	wp_enqueue_style( 'twentysixteen-ie8', get_template_directory_uri() . '/css/ie8.css', array( 'twentysixteen-style' ), '20150825' );
+	wp_enqueue_style( 'twentysixteen-ie8', get_template_directory_uri() . '/css/ie8.css', array( 'twentysixteen-style' ), '20151007' );
 	wp_style_add_data( 'twentysixteen-ie8', 'conditional', 'lt IE 9' );
 
 	// Load the Internet Explorer 7 specific stylesheet.
-	wp_enqueue_style( 'twentysixteen-ie7', get_template_directory_uri() . '/css/ie7.css', array( 'twentysixteen-style' ), '20150825' );
+	wp_enqueue_style( 'twentysixteen-ie7', get_template_directory_uri() . '/css/ie7.css', array( 'twentysixteen-style' ), '20151007' );
 	wp_style_add_data( 'twentysixteen-ie7', 'conditional', 'lt IE 8' );
 
 	// Load the html5 shiv.
 	wp_enqueue_script( 'twentysixteen-html5', get_template_directory_uri() . '/js/html5.js', array(), '3.7.3' );
 	wp_script_add_data( 'twentysixteen-html5', 'conditional', 'lt IE 9' );
 
-	wp_enqueue_script( 'twentysixteen-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20150825', true );
+	wp_enqueue_script( 'twentysixteen-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20151007', true );
 
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		wp_enqueue_script( 'comment-reply' );
 	}
 
 	if ( is_singular() && wp_attachment_is_image() ) {
-		wp_enqueue_script( 'twentysixteen-keyboard-image-navigation', get_template_directory_uri() . '/js/keyboard-image-navigation.js', array( 'jquery' ), '20150825' );
+		wp_enqueue_script( 'twentysixteen-keyboard-image-navigation', get_template_directory_uri() . '/js/keyboard-image-navigation.js', array( 'jquery' ), '20151007' );
 	}
 
-	wp_enqueue_script( 'twentysixteen-script', get_template_directory_uri() . '/js/functions.js', array( 'jquery' ), '20150825', true );
+	wp_enqueue_script( 'twentysixteen-script', get_template_directory_uri() . '/js/functions.js', array( 'jquery' ), '20151007', true );
 
 	wp_localize_script( 'twentysixteen-script', 'screenReaderText', array(
 		'expand'   => __( 'expand child menu', 'twentysixteen' ),
@@ -337,3 +337,25 @@ require get_template_directory() . '/inc/template-tags.php';
  * Customizer additions.
  */
 require get_template_directory() . '/inc/customizer.php';
+
+/*
+ * Add image size to enhance responsive image functionality
+ *
+ * @link https://developer.wordpress.org/reference/functions/add_image_size/
+ */
+add_image_size( 'max-content', 600, 600 );
+
+/*
+ * Add custom image sizes attribute to enhance responsive image functionality
+ *
+ * @link https://core.trac.wordpress.org/browser/trunk/src/wp-includes/media.php#L1035
+ */
+add_filter( 'wp_image_sizes_args', 'twentysixteen_image_sizes_attr', 10 , 3 );
+function twentysixteen_image_sizes_attr( $args, $id, $size ) {
+    if ( $size == 'full' || $size == 'large' ) {
+        $args['sizes'] = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1319px) 44vw, 600px';
+    } elseif ( $size == 'post-thumbnail' ) {
+    	$args['sizes'] = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1379px) 62vw, 840px';
+    }
+    return $args;
+}

--- a/functions.php
+++ b/functions.php
@@ -344,8 +344,8 @@ require get_template_directory() . '/inc/customizer.php';
  *
  * @since Twenty Sixteen 1.0
  *
- * @param string       $sizes A source size value for use in a 'sizes' attribute.
- * @param array        $size  Image size. Accepts an array of width and height
+ * @param string $sizes A source size value for use in a 'sizes' attribute.
+ * @param array  $size  Image size. Accepts an array of width and height
  *                            values in pixels (in that order).
  * @return string A source size value for use in a content image 'sizes' attribute.
  */
@@ -366,13 +366,13 @@ add_filter( 'wp_get_attachment_image_sizes', 'twentysixteen_content_image_sizes_
  *
  * @since Twenty Sixteen 1.0
  *
- * @param string       $sizes A source size value for use in a 'sizes' attribute.
- * @param array        $size  Image size. Accepts an array of width and height
- *                            values in pixels (in that order).
+ * @param array $attr Attributes for the image markup.
+ * @param int  $attachment Image attachment ID.
+ * @param array $size Registered image size or flat array of height and width dimensions.
  * @return string A source size value for use in a post thumbnail 'sizes' attribute.
  */
 function twentysixteen_post_thumbnail_sizes_attr( $attr, $attachment, $size ) {
-	if ( $size === 'post-thumbnail' ) {
+	if ( 'post-thumbnail' === $size ) {
 		is_active_sidebar( 'sidebar-1' ) && $attr['sizes'] = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1362px) 62vw, 840px';
 		false === is_active_sidebar( 'sidebar-1' ) && $attr['sizes'] = '(max-width: 709px) 85vw, (max-width: 909px) 65vw, (max-width: 1362px) 88vw, 1200px';
 	}

--- a/functions.php
+++ b/functions.php
@@ -350,10 +350,12 @@ require get_template_directory() . '/inc/customizer.php';
  * @return string A source size value for use in a 'sizes' attribute.
  */
 function twentysixteen_image_sizes_attr( $sizes, $id, $size ) {
-	if ( 'large' === $size ) {
+	if ( 'large' === $size && 'post' === get_post_type() ) {
 		$sizes = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1362px) 44vw, 600px';
-	} elseif ( 'full' === $size || 'post-thumbnail' === $size ) {
+	} elseif ( 'full' === $size || ( 'page' === get_post_type() && 'large' === $size ) || ( 'post-thumbnail' === $size &&  is_active_sidebar( 'sidebar-1' ) ) ) {
 		$sizes = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1362px) 62vw, 840px';
+	} elseif ( false === is_active_sidebar( 'sidebar-1' ) && 'post-thumbnail' === $size ) {
+		$sizes = '(max-width: 709px) 85vw, (max-width: 909px) 65vw, (max-width: 1362px) 88vw, 1200px';
 	}
 	return $sizes;
 }

--- a/functions.php
+++ b/functions.php
@@ -72,6 +72,13 @@ function twentysixteen_setup() {
 	add_theme_support( 'post-thumbnails' );
 	set_post_thumbnail_size( 1200, 0, true );
 
+	/*
+	 * Add image size to enhance responsive image functionality
+	 *
+	 * @link https://developer.wordpress.org/reference/functions/add_image_size/
+	 */
+	add_image_size( 'intermediate-width', 600, 600 );
+
 	// This theme uses wp_nav_menu() in two locations.
 	register_nav_menus( array(
 		'primary' => __( 'Primary Menu', 'twentysixteen' ),
@@ -239,32 +246,32 @@ function twentysixteen_scripts() {
 	wp_enqueue_style( 'twentysixteen-style', get_stylesheet_uri() );
 
 	// Load the Internet Explorer specific stylesheet.
-	wp_enqueue_style( 'twentysixteen-ie', get_template_directory_uri() . '/css/ie.css', array( 'twentysixteen-style' ), '20151007' );
+	wp_enqueue_style( 'twentysixteen-ie', get_template_directory_uri() . '/css/ie.css', array( 'twentysixteen-style' ), '20150825' );
 	wp_style_add_data( 'twentysixteen-ie', 'conditional', 'lt IE 10' );
 
 	// Load the Internet Explorer 8 specific stylesheet.
-	wp_enqueue_style( 'twentysixteen-ie8', get_template_directory_uri() . '/css/ie8.css', array( 'twentysixteen-style' ), '20151007' );
+	wp_enqueue_style( 'twentysixteen-ie8', get_template_directory_uri() . '/css/ie8.css', array( 'twentysixteen-style' ), '20150825' );
 	wp_style_add_data( 'twentysixteen-ie8', 'conditional', 'lt IE 9' );
 
 	// Load the Internet Explorer 7 specific stylesheet.
-	wp_enqueue_style( 'twentysixteen-ie7', get_template_directory_uri() . '/css/ie7.css', array( 'twentysixteen-style' ), '20151007' );
+	wp_enqueue_style( 'twentysixteen-ie7', get_template_directory_uri() . '/css/ie7.css', array( 'twentysixteen-style' ), '20150825' );
 	wp_style_add_data( 'twentysixteen-ie7', 'conditional', 'lt IE 8' );
 
 	// Load the html5 shiv.
 	wp_enqueue_script( 'twentysixteen-html5', get_template_directory_uri() . '/js/html5.js', array(), '3.7.3' );
 	wp_script_add_data( 'twentysixteen-html5', 'conditional', 'lt IE 9' );
 
-	wp_enqueue_script( 'twentysixteen-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20151007', true );
+	wp_enqueue_script( 'twentysixteen-skip-link-focus-fix', get_template_directory_uri() . '/js/skip-link-focus-fix.js', array(), '20150825', true );
 
 	if ( is_singular() && comments_open() && get_option( 'thread_comments' ) ) {
 		wp_enqueue_script( 'comment-reply' );
 	}
 
 	if ( is_singular() && wp_attachment_is_image() ) {
-		wp_enqueue_script( 'twentysixteen-keyboard-image-navigation', get_template_directory_uri() . '/js/keyboard-image-navigation.js', array( 'jquery' ), '20151007' );
+		wp_enqueue_script( 'twentysixteen-keyboard-image-navigation', get_template_directory_uri() . '/js/keyboard-image-navigation.js', array( 'jquery' ), '20150825' );
 	}
 
-	wp_enqueue_script( 'twentysixteen-script', get_template_directory_uri() . '/js/functions.js', array( 'jquery' ), '20151007', true );
+	wp_enqueue_script( 'twentysixteen-script', get_template_directory_uri() . '/js/functions.js', array( 'jquery' ), '20150825', true );
 
 	wp_localize_script( 'twentysixteen-script', 'screenReaderText', array(
 		'expand'   => __( 'expand child menu', 'twentysixteen' ),
@@ -339,23 +346,26 @@ require get_template_directory() . '/inc/template-tags.php';
 require get_template_directory() . '/inc/customizer.php';
 
 /*
- * Add image size to enhance responsive image functionality
  *
- * @link https://developer.wordpress.org/reference/functions/add_image_size/
- */
-add_image_size( 'max-content', 600, 600 );
-
-/*
- * Add custom image sizes attribute to enhance responsive image functionality
  *
  * @link https://core.trac.wordpress.org/browser/trunk/src/wp-includes/media.php#L1035
  */
-add_filter( 'wp_image_sizes_args', 'twentysixteen_image_sizes_attr', 10 , 3 );
+/**
+ * Add custom image sizes attribute to enhance responsive image functionality
+ *
+ * @since Twenty Sixteen 1.0
+ *
+ * @param array $args An array of arguments used to create a 'sizes' attribute.
+ * @param int $attachment_id Post ID of the original image.
+ * @param string $size Name of the image size being used.
+ * @return string A sizes attribute to be used on an image with a srcset attribute
+ */
 function twentysixteen_image_sizes_attr( $args, $id, $size ) {
-    if ( $size == 'full' || $size == 'large' ) {
-        $args['sizes'] = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1319px) 44vw, 600px';
-    } elseif ( $size == 'post-thumbnail' ) {
-    	$args['sizes'] = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1379px) 62vw, 840px';
-    }
-    return $args;
+	if ( 'large' == $size ) {
+		$args['sizes'] = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1319px) 44vw, 600px';
+	} elseif ( 'full' == $size || 'post-thumbnail' == $size ) {
+		$args['sizes'] = '(max-width: 709px) 85vw, (max-width: 909px) 66vw, (max-width: 984px) 60vw, (max-width: 1379px) 62vw, 840px';
+	}
+	return $args;
 }
+add_filter( 'wp_image_sizes_args', 'twentysixteen_image_sizes_attr', 10 , 3 );

--- a/header.php
+++ b/header.php
@@ -76,12 +76,13 @@
 			<?php if ( get_header_image() ) : ?>
 				<?php
 					/**
-					 * Filter the default twentysixteen header image sizes attribute.
+					 * Filter the default twentysixteen custom header sizes attribute.
 					 *
 					 * @since Twenty Sixteen 1.0
 					 *
-					 * @param string $sizes A valid sizes attribute. Default
-					 *                '(max-width: 709px) 85vw, (max-width: 909px) 81vw, (max-width: 1362px) 88vw, 1200px'.
+					 * @param string $custom_header_sizes sizes attribute
+					 * for Custom Header. Default '(max-width: 709px) 85vw,
+					 * (max-width: 909px) 81vw, (max-width: 1362px) 88vw, 1200px'.
 					 */
 					$custom_header_sizes = apply_filters( 'twentysixteen_custom_header_sizes', '(max-width: 709px) 85vw, (max-width: 909px) 81vw, (max-width: 1362px) 88vw, 1200px' );
 				?>

--- a/header.php
+++ b/header.php
@@ -76,7 +76,7 @@
 			<?php if ( get_header_image() ) : ?>
 				<div class="header-image">
 					<a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
-						<img src="<?php header_image(); ?>" srcset="<?php echo esc_attr( wp_get_attachment_image_srcset( get_custom_header()->attachment_id ) ); ?>" sizes="(max-width: 1319px) 88vw, 1320px" width="<?php echo esc_attr( get_custom_header()->width ); ?>" height="<?php echo esc_attr( get_custom_header()->height ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>">
+						<img src="<?php header_image(); ?>" srcset="<?php echo esc_attr( wp_get_attachment_image_srcset( get_custom_header()->attachment_id ) ); ?>" sizes="(max-width: 1319px) 88vw, 1200px" width="<?php echo esc_attr( get_custom_header()->width ); ?>" height="<?php echo esc_attr( get_custom_header()->height ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>">
 					</a>
 				</div>
 			<?php endif; // End header image check. ?>

--- a/header.php
+++ b/header.php
@@ -76,7 +76,7 @@
 			<?php if ( get_header_image() ) : ?>
 				<div class="header-image">
 					<a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
-						<img src="<?php header_image(); ?>" width="<?php echo esc_attr( get_custom_header()->width ); ?>" height="<?php echo esc_attr( get_custom_header()->height ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>">
+						<img src="<?php header_image(); ?>" srcset="<?php echo esc_attr( wp_get_attachment_image_srcset( get_custom_header()->attachment_id ) ); ?>" sizes="(max-width: 1319px) 88vw, 1320px" width="<?php echo esc_attr( get_custom_header()->width ); ?>" height="<?php echo esc_attr( get_custom_header()->height ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>">
 					</a>
 				</div>
 			<?php endif; // End header image check. ?>

--- a/header.php
+++ b/header.php
@@ -76,7 +76,7 @@
 			<?php if ( get_header_image() ) : ?>
 				<div class="header-image">
 					<a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
-						<img src="<?php header_image(); ?>" srcset="<?php echo esc_attr( wp_get_attachment_image_srcset( get_custom_header()->attachment_id ) ); ?>" sizes="(max-width: 709px) 85vw, (max-width: 909px) 80vw, (max-width: 1361px) 88vw, 1200px" width="<?php echo esc_attr( get_custom_header()->width ); ?>" height="<?php echo esc_attr( get_custom_header()->height ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>">
+						<img src="<?php header_image(); ?>" srcset="<?php echo esc_attr( wp_get_attachment_image_srcset( get_custom_header()->attachment_id ) ); ?>" sizes="(max-width: 709px) 85vw, (max-width: 909px) 80vw, (max-width: 1362px) 88vw, 1200px" width="<?php echo esc_attr( get_custom_header()->width ); ?>" height="<?php echo esc_attr( get_custom_header()->height ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>">
 					</a>
 				</div>
 			<?php endif; // End header image check. ?>

--- a/header.php
+++ b/header.php
@@ -76,7 +76,7 @@
 			<?php if ( get_header_image() ) : ?>
 				<div class="header-image">
 					<a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
-						<img src="<?php header_image(); ?>" srcset="<?php echo esc_attr( wp_get_attachment_image_srcset( get_custom_header()->attachment_id ) ); ?>" sizes="(max-width: 1319px) 88vw, 1200px" width="<?php echo esc_attr( get_custom_header()->width ); ?>" height="<?php echo esc_attr( get_custom_header()->height ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>">
+						<img src="<?php header_image(); ?>" srcset="<?php echo esc_attr( wp_get_attachment_image_srcset( get_custom_header()->attachment_id ) ); ?>" sizes="(max-width: 709px) 85vw, (max-width: 909px) 80vw, (max-width: 1361px) 88vw, 1200px" width="<?php echo esc_attr( get_custom_header()->width ); ?>" height="<?php echo esc_attr( get_custom_header()->height ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>">
 					</a>
 				</div>
 			<?php endif; // End header image check. ?>

--- a/header.php
+++ b/header.php
@@ -74,9 +74,20 @@
 			</div><!-- .site-header-main -->
 
 			<?php if ( get_header_image() ) : ?>
+				<?php
+					/**
+					 * Filter the default twentysixteen header image sizes attribute.
+					 *
+					 * @since Twenty Sixteen 1.0
+					 *
+					 * @param string $sizes A valid sizes attribute. Default
+					 *                '(max-width: 709px) 85vw, (max-width: 909px) 81vw, (max-width: 1362px) 88vw, 1200px'.
+					 */
+					$custom_header_sizes = apply_filters( 'twentysixteen_custom_header_sizes', '(max-width: 709px) 85vw, (max-width: 909px) 81vw, (max-width: 1362px) 88vw, 1200px' );
+				?>
 				<div class="header-image">
 					<a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home">
-						<img src="<?php header_image(); ?>" srcset="<?php echo esc_attr( wp_get_attachment_image_srcset( get_custom_header()->attachment_id ) ); ?>" sizes="(max-width: 709px) 85vw, (max-width: 909px) 80vw, (max-width: 1362px) 88vw, 1200px" width="<?php echo esc_attr( get_custom_header()->width ); ?>" height="<?php echo esc_attr( get_custom_header()->height ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>">
+						<img src="<?php header_image(); ?>" srcset="<?php echo esc_attr( wp_get_attachment_image_srcset( get_custom_header()->attachment_id ) ); ?>" sizes="<?php echo esc_attr( $custom_header_sizes ); ?>" width="<?php echo esc_attr( get_custom_header()->width ); ?>" height="<?php echo esc_attr( get_custom_header()->height ); ?>" alt="<?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?>">
 					</a>
 				</div>
 			<?php endif; // End header image check. ?>


### PR DESCRIPTION
Hey @iamtakashi here's an overview of the updates since the last PR:
- Version numbers have been fixed
- Extra image size moved to twentysixteen_setup
- 840px wide image in pages and post content accounted for 
- Custom header size fixed, only 1200px wide
- add_filter moved to correct location in funtions.php 
- Travis formatting issues corrected
- We have a MQ value in the `sizes` attribute that's larger than 1320px, but that's because I noticed that the image can still get larger after the browser is wider than 1320px if it's a full size image. It's only a difference of 59px but I left it in for the sake of precision
