### PR TITLE
Removing redundancy with WAI-ARIA in HTML

### DIFF
--- a/404.php
+++ b/404.php
@@ -10,7 +10,7 @@
 get_header(); ?>
 
 	<div id="primary" class="content-area">
-		<main id="main" class="site-main" role="main">
+		<main id="main" class="site-main">
 
 			<section class="error-404 not-found">
 				<header class="page-header">

--- a/archive.php
+++ b/archive.php
@@ -19,7 +19,7 @@
 get_header(); ?>
 
 	<div id="primary" class="content-area">
-		<main id="main" class="site-main" role="main">
+		<main id="main" class="site-main">
 
 		<?php if ( have_posts() ) : ?>
 

--- a/footer.php
+++ b/footer.php
@@ -12,9 +12,9 @@
 
 		</div><!-- .site-content -->
 
-		<footer id="colophon" class="site-footer" role="contentinfo">
+		<footer id="colophon" class="site-footer">
 			<?php if ( has_nav_menu( 'primary' ) ) : ?>
-				<nav class="main-navigation" role="navigation" aria-label="<?php _e( 'Footer Primary Menu', 'twentysixteen' ); ?>">
+				<nav class="main-navigation" aria-label="<?php _e( 'Footer Primary Menu', 'twentysixteen' ); ?>">
 					<?php
 						wp_nav_menu( array(
 							'theme_location' => 'primary',
@@ -25,7 +25,7 @@
 			<?php endif; ?>
 
 			<?php if ( has_nav_menu( 'social' ) ) : ?>
-				<nav class="social-navigation" role="navigation" aria-label="<?php _e( 'Footer Social Links Menu', 'twentysixteen' ); ?>">
+				<nav class="social-navigation" aria-label="<?php _e( 'Footer Social Links Menu', 'twentysixteen' ); ?>">
 					<?php
 						wp_nav_menu( array(
 							'theme_location' => 'social',

--- a/header.php
+++ b/header.php
@@ -26,7 +26,7 @@
 	<div class="site-inner">
 		<a class="skip-link screen-reader-text" href="#content"><?php _e( 'Skip to content', 'twentysixteen' ); ?></a>
 
-		<header id="masthead" class="site-header" role="banner">
+		<header id="masthead" class="site-header">
 			<div class="site-header-main">
 				<div class="site-branding">
 					<?php if ( is_front_page() && is_home() ) : ?>
@@ -46,7 +46,7 @@
 
 					<div id="site-header-menu" class="site-header-menu">
 						<?php if ( has_nav_menu( 'primary' ) ) : ?>
-							<nav id="site-navigation" class="main-navigation" role="navigation" aria-label="<?php _e( 'Primary Menu', 'twentysixteen' ); ?>">
+							<nav id="site-navigation" class="main-navigation" aria-label="<?php _e( 'Primary Menu', 'twentysixteen' ); ?>">
 								<?php
 									wp_nav_menu( array(
 										'theme_location' => 'primary',
@@ -57,7 +57,7 @@
 						<?php endif; ?>
 
 						<?php if ( has_nav_menu( 'social' ) ) : ?>
-							<nav id="social-navigation" class="social-navigation" role="navigation" aria-label="<?php _e( 'Social Links Menu', 'twentysixteen' ); ?>">
+							<nav id="social-navigation" class="social-navigation" aria-label="<?php _e( 'Social Links Menu', 'twentysixteen' ); ?>">
 								<?php
 									wp_nav_menu( array(
 										'theme_location' => 'social',

--- a/image.php
+++ b/image.php
@@ -10,7 +10,7 @@
 get_header(); ?>
 
 	<div id="primary" class="content-area">
-		<main id="main" class="site-main" role="main">
+		<main id="main" class="site-main">
 
 			<?php
 				// Start the loop.

--- a/index.php
+++ b/index.php
@@ -17,7 +17,7 @@
 get_header(); ?>
 
 	<div id="primary" class="content-area">
-		<main id="main" class="site-main" role="main">
+		<main id="main" class="site-main">
 
 		<?php if ( have_posts() ) : ?>
 

--- a/search.php
+++ b/search.php
@@ -10,7 +10,7 @@
 get_header(); ?>
 
 	<section id="primary" class="content-area">
-		<main id="main" class="site-main" role="main">
+		<main id="main" class="site-main">
 
 		<?php if ( have_posts() ) : ?>
 

--- a/sidebar-content-bottom.php
+++ b/sidebar-content-bottom.php
@@ -13,7 +13,7 @@ if ( ! is_active_sidebar( 'sidebar-2' ) && ! is_active_sidebar( 'sidebar-3' ) ) 
 
 // If we get this far, we have widgets. Let's do this.
 ?>
-<div id="content-bottom-widgets" class="content-bottom-widgets" role="complementary">
+<aside id="content-bottom-widgets" class="content-bottom-widgets">
 	<?php if ( is_active_sidebar( 'sidebar-2' ) ) : ?>
 		<div class="widget-area">
 			<?php dynamic_sidebar( 'sidebar-2' ); ?>
@@ -25,4 +25,4 @@ if ( ! is_active_sidebar( 'sidebar-2' ) && ! is_active_sidebar( 'sidebar-3' ) ) 
 			<?php dynamic_sidebar( 'sidebar-3' ); ?>
 		</div><!-- .widget-area -->
 	<?php endif; ?>
-</div><!-- .content-bottom-widgets -->
+</aside><!-- .content-bottom-widgets -->

--- a/sidebar.php
+++ b/sidebar.php
@@ -9,7 +9,7 @@
 ?>
 
 <?php if ( is_active_sidebar( 'sidebar-1' )  ) : ?>
-	<div id="secondary" class="sidebar widget-area" role="complementary">
+	<aside id="secondary" class="sidebar widget-area">
 		<?php dynamic_sidebar( 'sidebar-1' ); ?>
-	</div><!-- .sidebar .widget-area -->
+	</aside><!-- .sidebar .widget-area -->
 <?php endif; ?>

--- a/singular.php
+++ b/singular.php
@@ -16,7 +16,7 @@
 get_header(); ?>
 
 <div id="primary" class="content-area">
-	<main id="main" class="site-main" role="main">
+	<main id="main" class="site-main">
 		<?php
 		// Start the loop.
 		while ( have_posts() ) : the_post();


### PR DESCRIPTION
WAI-ARIA roles are awesome to use for accessibility… when they are useful. Most HTML5 roles defined in TwentySixteen are redundant and not necessary. The semantics of these ARIA roles are already included in most of the elements by default.

I am referencing two articles, one of which is written by Steve Faulkner, a well respected Accessibility expert:
http://html5doctor.com/on-html-belts-and-aria-braces/
http://www.sitepoint.com/avoiding-redundancy-wai-aria-html-pages/

The form search ARIA role might also be something to reconsider:
http://adrianroselli.com/2015/08/where-to-put-your-search-role.html
