### PR TITLE
Change widget container from aside to section

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -142,8 +142,8 @@ function twentysixteen_widgets_init() {
 		'name'          => __( 'Sidebar', 'twentysixteen' ),
 		'id'            => 'sidebar-1',
 		'description'   => __( 'Add widgets here to appear in your sidebar.', 'twentysixteen' ),
-		'before_widget' => '<aside id="%1$s" class="widget %2$s">',
-		'after_widget'  => '</aside>',
+		'before_widget' => '<section id="%1$s" class="widget %2$s">',
+		'after_widget'  => '</section>',
 		'before_title'  => '<h2 class="widget-title">',
 		'after_title'   => '</h2>',
 	) );
@@ -152,8 +152,8 @@ function twentysixteen_widgets_init() {
 		'name'          => __( 'Content Bottom 1', 'twentysixteen' ),
 		'id'            => 'sidebar-2',
 		'description'   => __( 'Appears at the bottom of the content on posts and pages.', 'twentysixteen' ),
-		'before_widget' => '<aside id="%1$s" class="widget %2$s">',
-		'after_widget'  => '</aside>',
+		'before_widget' => '<section id="%1$s" class="widget %2$s">',
+		'after_widget'  => '</section>',
 		'before_title'  => '<h2 class="widget-title">',
 		'after_title'   => '</h2>',
 	) );
@@ -162,8 +162,8 @@ function twentysixteen_widgets_init() {
 		'name'          => __( 'Content Bottom 2', 'twentysixteen' ),
 		'id'            => 'sidebar-3',
 		'description'   => __( 'Appears at the bottom of the content on posts and pages.', 'twentysixteen' ),
-		'before_widget' => '<aside id="%1$s" class="widget %2$s">',
-		'after_widget'  => '</aside>',
+		'before_widget' => '<section id="%1$s" class="widget %2$s">',
+		'after_widget'  => '</section>',
 		'before_title'  => '<h2 class="widget-title">',
 		'after_title'   => '</h2>',
 	) );


### PR DESCRIPTION
Using aside creates unnecessary and redundant landmark regions, complicating navigation for users of screen readers. See issue #355
