### PR TITLE
Enable dropdown fix for touch from 910px wide viewport

### DIFF
--- a/js/functions.js
+++ b/js/functions.js
@@ -78,7 +78,7 @@
 
 		// Toggle `focus` class to allow submenu access on tablets.
 		function toggleFocusClassTouchScreen() {
-			if ( window.innerWidth > 910 ) {
+			if ( window.innerWidth >= 910 ) {
 				$( document.body ).on( 'touchstart.twentysixteen', function( e ) {
 					if ( ! $( e.target ).closest( '.main-navigation li' ).length ) {
 						$( '.main-navigation li' ).removeClass( 'focus' );


### PR DESCRIPTION
The normal navigation starts to appear from 910px width.
