### PR TITLE
Fix a typo in a selector.

### DIFF
--- a/style.css
+++ b/style.css
@@ -811,7 +811,7 @@ a:active {
 }
 
 .main-navigation .current-menu-item > a,
-.main-navigation .current_page_ancestor > a {
+.main-navigation .current-menu-ancestor > a {
 	font-weight: 700;
 }
 


### PR DESCRIPTION
This theme doesn't have the fallback page navigation. Therefore this was meant to be "menu ancestor"
