### PR TITLE
More accessible color schemes

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -237,19 +237,19 @@ function twentysixteen_get_color_schemes() {
 			'colors' => array(
 				'#616a73',
 				'#4d545c',
-				'#aaaaaa',
-				'#ededed',
-				'#ededed',
+				'#c7c7c7',
+				'#f2f2f2',
+				'#f2f2f2',
 			),
 		),
-		'green' => array(
-			'label'  => __( 'Green', 'twentysixteen' ),
+		'red' => array(
+			'label'  => __( 'Red', 'twentysixteen' ),
 			'colors' => array(
 				'#ffffff',
-				'#acc1a2',
-				'#6d8c87',
-				'#ffffff',
-				'#efeef4',
+				'#ff675f',
+				'#640c1f',
+				'#402b30',
+				'#402b30',
 			),
 		),
 		'yellow' => array(
@@ -257,9 +257,9 @@ function twentysixteen_get_color_schemes() {
 			'colors' => array(
 				'#3b3721',
 				'#ffef8e',
-				'#7f7d6f',
-				'#3b3721',
 				'#774e24',
+				'#3b3721',
+				'#5b4d3e',
 			),
 		),
 	) );


### PR DESCRIPTION
As a part of the effort to deliver better accessibility, I've improved Gray and Yellow colour schemes, and removed Green scheme and introduced a new Red colour scheme. 

With this change all text colours have the contrast ratio more than 4.5:1 that WCAG 2.0 level AA requires.

The new colour palettes are the following. I omitted the background border colour here as it's irrelevant in this change. Each text colour is evaluated against the page background colour.

```
**NAME**
Page Background Colour
Link Colour
Main Text Color
Secondary Text Colour

**DEFAULT**
#ffffff
#007acc (4.51:1)
#1a1a1a (17.40:1)
#686868 (5.57:1)

**DARK**
#1a1a1a
#9adffd (11.89:1)
#e5e5e5 (13.82:1)
#c1c1c1 (9.67:1)

**GRAY**
#4d545c
#c7c7c7 (4.54:1)
#f2f2f2 (6.85:1)
#f2f2f2 (6.85:1)

**RED**
#ff675f
#640c1f (4.56:1)
#402b30 (4.58:1)
#402b30 (4.58:1)

**YELLOW**
#ffef8e
#774e24 (6.20:1)
#3b3721 (10.25:1) 
#5b4d3e (6.98:1)
```
