### PR TITLE
Fix Keyboard Image Navigation

### DIFF
--- a/js/keyboard-image-navigation.js
+++ b/js/keyboard-image-navigation.js
@@ -4,7 +4,7 @@
 
 ( function( $ ) {
 	$( document ).on( 'keydown.twentysixteen', function( e ) {
-		var url = '';
+		var url = false;
 
 		// Left arrow key code.
 		if ( 37 === e.which ) {
@@ -19,7 +19,7 @@
 			return;
 		}
 
-		if ( '' !== url && ! $( 'textarea, input' ).is( ':focus' ) ) {
+		if ( url && ! $( 'textarea, input' ).is( ':focus' ) ) {
 			window.location = url;
 		}
 	} );


### PR DESCRIPTION
Reported here: https://wordpress.org/support/topic/keyboard-image-navigation-from-the-last-image-returns-a-404
