### PR TITLE
Make sure the text for pagination link is hidden.

### DIFF
--- a/style.css
+++ b/style.css
@@ -1174,10 +1174,10 @@ a:active {
 .pagination .prev:before,
 .pagination .next:before {
 	font-size: 32px;
-	height: 52px;
+	height: 53px;
 	line-height: 52px;
 	position: relative;
-	width: 52px;
+	width: 53px;
 }
 
 .pagination .prev:hover,


### PR DESCRIPTION
Reported here: https://wordpress.org/support/topic/previous-page-and-next-page-is-not-displayed-well?replies=2

This makes sure the text is outside of the anchor and hidden.
