### PR TITLE
Remove select element from the Main Text Color for color schemes.

### DIFF
--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -937,7 +937,6 @@ function twentysixteen_main_text_color_css() {
 	$css = '
 		/* Custom Main Text Color */
 		body,
-		select,
 		blockquote cite,
 		blockquote small,
 		.main-navigation a,

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -532,7 +532,6 @@ function twentysixteen_get_color_scheme_css( $colors ) {
 
 	/* Main Text Color */
 	body,
-	select,
 	blockquote cite,
 	blockquote small,
 	.main-navigation a,


### PR DESCRIPTION
On darker schemes, it caused the text to be unreadable in Firefox. 

First contribution— w.org username @kraftbj

Fixes #373 

Before:
![screen shot 2015-11-11 at 16 53 40](https://cloud.githubusercontent.com/assets/88897/11105532/07e9a352-8895-11e5-9c72-349dbb7a3100.png)
![screen shot 2015-11-11 at 16 39 40](https://cloud.githubusercontent.com/assets/88897/11105533/0b3d9e8c-8895-11e5-8d47-6cc9fb5c8482.png)

After:
![screen shot 2015-11-11 at 16 51 02](https://cloud.githubusercontent.com/assets/88897/11105537/1105d2c6-8895-11e5-80a1-81b6f45efb1d.png)
![screen shot 2015-11-11 at 16 51 51](https://cloud.githubusercontent.com/assets/88897/11105538/12a555de-8895-11e5-849f-d28782f2d4dd.png)
![screen shot 2015-11-11 at 16 52 01](https://cloud.githubusercontent.com/assets/88897/11105540/154762c8-8895-11e5-882e-ce9cc55be31b.png)
![screen shot 2015-11-11 at 16 52 08](https://cloud.githubusercontent.com/assets/88897/11105543/19790e00-8895-11e5-807f-8eff9c3e5109.png)
