### PR TITLE
Remove singular.php and Add single.php and page.php

### DIFF
--- a/page.php
+++ b/page.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * The template for displaying pages
+ *
+ * This is the template that displays all pages by default.
+ * Please note that this is the WordPress construct of pages and that
+ * other "pages" on your WordPress site will use a different template.
+ *
+ * @package WordPress
+ * @subpackage Twenty_Sixteen
+ * @since Twenty Sixteen 1.0
+ */
+
+get_header(); ?>
+
+<div id="primary" class="content-area">
+	<main id="main" class="site-main" role="main">
+		<?php
+		// Start the loop.
+		while ( have_posts() ) : the_post();
+
+			// Include the page content template.
+			get_template_part( 'template-parts/content', 'page' );
+
+			// If comments are open or we have at least one comment, load up the comment template.
+			if ( comments_open() || get_comments_number() ) {
+				comments_template();
+			}
+
+			// End of the loop.
+		endwhile;
+		?>
+
+	</main><!-- .site-main -->
+
+	<?php get_sidebar( 'content-bottom' ); ?>
+
+</div><!-- .content-area -->
+
+<?php get_sidebar(); ?>
+<?php get_footer(); ?>

--- a/single.php
+++ b/single.php
@@ -1,12 +1,6 @@
 <?php
 /**
- * The template for displaying all pages, single posts and attachments
- *
- * This is a new template file that WordPress introduced in
- * version 4.3. Note that it uses conditional logic to display
- * different content based on the post type.
- *
- * @link https://codex.wordpress.org/Template_Hierarchy
+ * The template for displaying all single posts and attachments
  *
  * @package WordPress
  * @subpackage Twenty_Sixteen
@@ -21,12 +15,8 @@ get_header(); ?>
 		// Start the loop.
 		while ( have_posts() ) : the_post();
 
-			// Include the page content template.
-			if ( is_singular( 'page' ) ) {
-				get_template_part( 'template-parts/content', 'page' );
-			} else {
-				get_template_part( 'template-parts/content', 'single' );
-			}
+			// Include the single post content template.
+			get_template_part( 'template-parts/content', 'single' );
 
 			// If comments are open or we have at least one comment, load up the comment template.
 			if ( comments_open() || get_comments_number() ) {
@@ -34,7 +24,7 @@ get_header(); ?>
 			}
 
 			if ( is_singular( 'attachment' ) ) {
-				// Parent post navigation
+				// Parent post navigation.
 				the_post_navigation( array(
 					'prev_text' => _x( '<span class="meta-nav">Published in</span><span class="post-title">%title</span>', 'Parent post link', 'twentysixteen' ),
 				) );


### PR DESCRIPTION
We've added `singular.php` in #206 but I have a second thought and I think this is not the right thing to do with Twenty Sixteen.

I saw <a href="https://github.com/Automattic/_s/pull/827">this thread in Underscores</a> and <a href="https://github.com/Automattic/_s/pull/827#issuecomment-142302778">what @obenland said</a> there struck to me. 

Especially this:

<blockquote>As a matter of fact, I think the only time it does make sense is when content, regardless of type, will always be displayed in the same way.</blockquote>


In Twenty Sixteen, pages and posts are displayed differently but posts and non-image attachments are the same. Hence this absolutely makes sense.

With this change, there will be one more template file and less "DRY" but having a`singular.php` with three content type checks doesn't seem to be the right thing to do for this theme.
