### PR TITLE
Move Screen Reader Text Span Inside the Translation String for Edit Link

### DIFF
--- a/image.php
+++ b/image.php
@@ -81,8 +81,8 @@ get_header(); ?>
 							edit_post_link(
 								sprintf(
 									/* translators: %s: Name of current post */
-									__( 'Edit %s', 'twentysixteen' ),
-									the_title( '<span class="screen-reader-text">', '</span>', false )
+									__( 'Edit<span class="screen-reader-text"> "%s"</span>', 'twentysixteen' ),
+									the_title( '', '', false )
 								),
 								'<span class="edit-link">',
 								'</span>'

--- a/template-parts/content-page.php
+++ b/template-parts/content-page.php
@@ -34,8 +34,8 @@
 		edit_post_link(
 			sprintf(
 				/* translators: %s: Name of current post */
-				__( 'Edit %s', 'twentysixteen' ),
-				the_title( '<span class="screen-reader-text">', '</span>', false )
+				__( 'Edit<span class="screen-reader-text"> "%s"</span>', 'twentysixteen' ),
+				the_title( '', '', false )
 			),
 			'<footer class="entry-footer"><span class="edit-link">',
 			'</span></footer><!-- .entry-footer -->'

--- a/template-parts/content-search.php
+++ b/template-parts/content-search.php
@@ -25,8 +25,8 @@
 				edit_post_link(
 					sprintf(
 						/* translators: %s: Name of current post */
-						__( 'Edit %s', 'twentysixteen' ),
-						the_title( '<span class="screen-reader-text">"', '"</span>', false )
+						__( 'Edit<span class="screen-reader-text"> "%s"</span>', 'twentysixteen' ),
+						the_title( '', '', false )
 					),
 					'<span class="edit-link">',
 					'</span>'
@@ -40,8 +40,8 @@
 			edit_post_link(
 				sprintf(
 					/* translators: %s: Name of current post */
-					__( 'Edit %s', 'twentysixteen' ),
-					the_title( '<span class="screen-reader-text">', '</span>', false )
+					__( 'Edit<span class="screen-reader-text"> "%s"</span>', 'twentysixteen' ),
+					the_title( '', '', false )
 				),
 				'<footer class="entry-footer"><span class="edit-link">',
 				'</span></footer><!-- .entry-footer -->'

--- a/template-parts/content-single.php
+++ b/template-parts/content-single.php
@@ -42,8 +42,8 @@
 			edit_post_link(
 				sprintf(
 					/* translators: %s: Name of current post */
-					__( 'Edit %s', 'twentysixteen' ),
-					the_title( '<span class="screen-reader-text">', '</span>', false )
+					__( 'Edit<span class="screen-reader-text"> "%s"</span>', 'twentysixteen' ),
+					the_title( '', '', false )
 				),
 				'<span class="edit-link">',
 				'</span>'

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -25,8 +25,8 @@
 		<?php
 			/* translators: %s: Name of current post */
 			the_content( sprintf(
-				__( 'Continue reading %s', 'twentysixteen' ),
-				the_title( '<span class="screen-reader-text">"', '"</span>', false )
+				__( 'Continue reading<span class="screen-reader-text"> %s</span>', 'twentysixteen' ),
+				the_title( '', '', false )
 			) );
 
 			wp_link_pages( array(
@@ -46,8 +46,8 @@
 			edit_post_link(
 				sprintf(
 					/* translators: %s: Name of current post */
-					__( 'Edit %s', 'twentysixteen' ),
-					the_title( '<span class="screen-reader-text">', '</span>', false )
+					__( 'Edit<span class="screen-reader-text"> "%s"</span>', 'twentysixteen' ),
+					the_title( '', '', false )
 				),
 				'<span class="edit-link">',
 				'</span>'


### PR DESCRIPTION
This is the current code in question:

```
/* translators: %s: Name of current post */
__( 'Edit %s', 'twentysixteen' ),
the_title( '<span class="screen-reader-text">', '</span>', false )
```

At least with Japanese (probably some other languages too), we need a particle between a verb and an object, but when the object is hidden, the particle also needs to be hidden.

Currently, the `span` is outside of the translation string so there is no way to hide particles in translation. And without it, the meaning isn't accurate for screen reader users.

So, it'd be better, like the comment link, to move the `span` inside the translation string so it's flexible and translators can hide particles if necessary.
