### PR TITLE
Edit Translation String for Continue Reading Link

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -181,7 +181,7 @@ function twentysixteen_excerpt_more() {
 	$link = sprintf( '<a href="%1$s" class="more-link">%2$s</a>',
 		esc_url( get_permalink( get_the_ID() ) ),
 		/* translators: %s: Name of current post */
-		sprintf( __( 'Continue reading %s', 'twentysixteen' ), '<span class="screen-reader-text">' . get_the_title( get_the_ID() ) . '</span>' )
+		sprintf( __( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'twentysixteen' ), get_the_title( get_the_ID() ) )
 	);
 	return ' &hellip; ' . $link;
 }

--- a/template-parts/content.php
+++ b/template-parts/content.php
@@ -25,7 +25,7 @@
 		<?php
 			/* translators: %s: Name of current post */
 			the_content( sprintf(
-				__( 'Continue reading<span class="screen-reader-text"> %s</span>', 'twentysixteen' ),
+				__( 'Continue reading<span class="screen-reader-text"> "%s"</span>', 'twentysixteen' ),
 				get_the_title()
 			) );
 


### PR DESCRIPTION
Related: #383
- Make the translation string for the continue reading link in `inc/template-tags.php` the same as `template-parts/content.php` to reduce the number of translations.
- Added missing quotes around the title placeholder in `template-parts/content.php`.
