### PR TITLE
Remove Unwanted Double Margin from Entry Footer

### DIFF
--- a/style.css
+++ b/style.css
@@ -3461,10 +3461,6 @@ p > video {
 		padding-bottom: 0;
 	}
 
-	.entry-footer {
-		margin-top: 4.3076923077em;
-	}
-
 	.comment-list + .comment-respond,
 	.comment-navigation + .comment-respond {
 		padding-top: 5.25em;


### PR DESCRIPTION
This was an oversight and shouldn't be there.
