### PR TITLE
Author avatar size should match size declared in style.css.

### DIFF
--- a/template-parts/biography.php
+++ b/template-parts/biography.php
@@ -18,7 +18,7 @@
 		 *
 		 * @param int $size The avatar height and width size in pixels.
 		 */
-		$author_bio_avatar_size = apply_filters( 'twentysixteen_author_bio_avatar_size', 49 );
+		$author_bio_avatar_size = apply_filters( 'twentysixteen_author_bio_avatar_size', 42 );
 
 		echo get_avatar( get_the_author_meta( 'user_email' ), $author_bio_avatar_size );
 		?>


### PR DESCRIPTION
I see this in style.css:

``` css
.author-avatar .avatar {
    float: left;
    height: 42px;
    margin: 0 1.75em 1.75em 0;
    width: 42px;
}
```

So I've changed this:

``` php
$author_bio_avatar_size = apply_filters( 'twentysixteen_author_bio_avatar_size', 49 );
```

to this:

``` php
$author_bio_avatar_size = apply_filters( 'twentysixteen_author_bio_avatar_size', 42 );
```

Probably a small oversight, or I could be missing something about why it was set to 49. Either way, thought I'd bring it up.
