### PR TITLE
Filter tag cloud widget font size to avoid !important in CSS.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -389,3 +389,19 @@ function twentysixteen_post_thumbnail_sizes_attr( $attr, $attachment, $size ) {
 	return $attr;
 }
 add_filter( 'wp_get_attachment_image_attributes', 'twentysixteen_post_thumbnail_sizes_attr', 10 , 3 );
+
+/**
+ * Modifies tag cloud widget arguments to have all tags in the widget same font size.
+ *
+ * @since Twenty Sixteen 1.1
+ *
+ * @param array $args Arguments for tag cloud widget.
+ * @return array A new modified arguments.
+ */
+function twentysixteen_widget_tag_cloud_args( $args ) {
+	$args['largest'] = 1;
+	$args['smallest'] = 1;
+	$args['unit'] = 'em';
+	return $args;
+}
+add_filter( 'widget_tag_cloud_args', 'twentysixteen_widget_tag_cloud_args' );

--- a/style.css
+++ b/style.css
@@ -1487,7 +1487,6 @@ blockquote:after,
 	border-radius: 2px;
 	display: inline-block;
 	font-family: Montserrat, "Helvetica Neue", sans-serif;
-	font-size: inherit !important;
 	line-height: 1;
 	margin: 0 0.1875em 0.4375em 0;
 	padding: 0.5625em 0.4375em 0.5em;


### PR DESCRIPTION
Twenty Sixteen has moved away from outdated looking tag cloud with various font sizes, and all tags a re the same size. This has been done with `!important` in the CSS which wasn't a great approach for child themes.

We should filter the size with `widget_tag_cloud_args` so that child themes can easily modify the style if needed.
