### PR TITLE
Remove an extra separator in post meta for single author blog

### DIFF
--- a/css/ie8.css
+++ b/css/ie8.css
@@ -153,15 +153,11 @@ code {
 	width: 50%;
 }
 
-.entry-footer > span:before {
+.entry-footer > span:after {
 	content: "\002f";
 	display: inline-block;
 	filter: alpha(opacity=70);
 	padding: 0 0.538461538em;
-}
-
-.entry-footer > span:first-child:before {
-	display: none;
 }
 
 .updated {

--- a/style.css
+++ b/style.css
@@ -1960,7 +1960,7 @@ body:not(.search-results) .entry-summary > :last-child,
 	color: #007acc;
 }
 
-.entry-footer > span:not(:first-child):before {
+.entry-footer > span:not(:last-child):after {
 	content: "\002f";
 	display: inline-block;
 	opacity: 0.7;
@@ -3514,7 +3514,7 @@ p > video {
 		width: 21.42857143%;
 	}
 
-	body:not(.search-results) article:not(.type-page) .entry-footer > span:not(:first-child):before {
+	body:not(.search-results) article:not(.type-page) .entry-footer > span:not(:last-child):after {
 		display: none;
 	}
 


### PR DESCRIPTION
Single author blog where the author avatar is hidden, an extra separator was visible.

![screen shot 2015-12-29 at 16 51 05](https://cloud.githubusercontent.com/assets/908665/12041554/5e42c1ca-ae6a-11e5-89be-9a8f7ddc06e1.png)

That should look like this and this PR intends to fix the issue.

![screen shot 2015-12-29 at 20 26 52](https://cloud.githubusercontent.com/assets/908665/12041582/9205f234-ae6a-11e5-8062-ef48168b7ffc.png)
