### PR TITLE
Remove unnecessary crop parameter

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -70,7 +70,7 @@ function twentysixteen_setup() {
 	 * @link http://codex.wordpress.org/Function_Reference/add_theme_support#Post_Thumbnails
 	 */
 	add_theme_support( 'post-thumbnails' );
-	set_post_thumbnail_size( 1200, 0, true );
+	set_post_thumbnail_size( 1200, 9999 );
 
 	// This theme uses wp_nav_menu() in two locations.
 	register_nav_menus( array(


### PR DESCRIPTION
The crop parameter was unnecessary because the theme allows unlimited height of post thumbnail, 

Also, I've changed the height to be `9999` instead of `0` to follow the unlimited height example on Codex page: https://codex.wordpress.org/Post_Thumbnails#Add_New_Post_Thumbnail_Sizes

This is just meant to clean-up and should not cause any issue or difference on the front-end but if we can have other sets of eye before merge, it'd be great.
