### PR TITLE
Prevent overflowing on small screens.

### DIFF
--- a/style.css
+++ b/style.css
@@ -230,6 +230,7 @@ input[type="search"]::-webkit-search-decoration {
 fieldset {
 	border: 1px solid #d1d1d1;
 	margin: 0 0 1.75em;
+	min-width: inherit;
 	padding: 0.875em;
 }
 


### PR DESCRIPTION
Webkit browsers set the min-width of `fieldset` elements to `-webkit-min-content`. min-content is the smallest measure that would fit around its content if all soft wrap opportunities within the box were taken.

On small screens it can happen that `fieldset` contains elements that are wider than the content area, resulting in `fieldset` overflowing to accommodate those elements. A good example for that is the Elements post on Theme Preview at http://wp-themes.com.

See https://core.trac.wordpress.org/ticket/35421
