### PR TITLE
JS functions: Replace the deprecated `.load()` method with `.on( 'load', fn )`.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -264,7 +264,7 @@ function twentysixteen_scripts() {
 		wp_enqueue_script( 'twentysixteen-keyboard-image-navigation', get_template_directory_uri() . '/js/keyboard-image-navigation.js', array( 'jquery' ), '20151104' );
 	}
 
-	wp_enqueue_script( 'twentysixteen-script', get_template_directory_uri() . '/js/functions.js', array( 'jquery' ), '20151204', true );
+	wp_enqueue_script( 'twentysixteen-script', get_template_directory_uri() . '/js/functions.js', array( 'jquery' ), '20160116', true );
 
 	wp_localize_script( 'twentysixteen-script', 'screenReaderText', array(
 		'expand'   => __( 'expand child menu', 'twentysixteen' ),

--- a/js/functions.js
+++ b/js/functions.js
@@ -160,7 +160,7 @@
 					newImg = new Image();
 					newImg.src = element.attr( 'src' );
 
-					$( newImg ).load( function() {
+					$( newImg ).on( 'load.twentysixteen', function() {
 						if ( newImg.width >= 840  ) {
 							element.addClass( 'below-entry-meta' );
 


### PR DESCRIPTION
Fixes #416.
