### PR TITLE
Change the logo size to be the physical pixel size

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -67,7 +67,7 @@ function twentysixteen_setup() {
 	/*
 	 * Enable support for site logo.
 	 */
-	add_image_size( 'twentysixteen-logo', 2400, 350 );
+	add_image_size( 'twentysixteen-logo', 1200, 175 );
 	add_theme_support( 'site-logo', array( 'size' => 'twentysixteen-logo' ) );
 
 	/*
@@ -430,4 +430,3 @@ function twentysixteen_logo_sizes_attr( $attr, $attachment, $size ) {
 	return $attr;
 }
 add_filter( 'wp_get_attachment_image_attributes', 'twentysixteen_logo_sizes_attr', 10 , 3 );
-

--- a/style.css
+++ b/style.css
@@ -1643,11 +1643,6 @@ blockquote:after,
 	display: block;
 }
 
-.site-logo {
-	max-height: 112px;
-	width: auto;
-}
-
 .wp-site-logo .site-title {
 	margin-top: 0.608695652em;
 }
@@ -2911,10 +2906,6 @@ p > video {
 	body:not(.search-results) .entry-summary li > ol,
 	body:not(.search-results) .entry-summary blockquote > ol {
 		margin-left: 1.473684211em;
-	}
-
-	.site-logo {
-		max-height: 175px;
 	}
 
 	.wp-site-logo .site-title {


### PR DESCRIPTION
The intention of the double size was to take account retina screens but, with core's responsive image sizes attribute, this method is rather troublesome. Image's `width` attribute was ignored by the CSS and a smaller and short logo was stretched by the `sizes` attribute.

It's best to specify the size with physical pixel size like custom header image and post thumbnails.
