### PR TITLE
Rename theme support feature from site-logo to custom-logo

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -68,7 +68,7 @@ function twentysixteen_setup() {
 	 * Enable support for site logo.
 	 */
 	add_image_size( 'twentysixteen-logo', 1200, 175 );
-	add_theme_support( 'site-logo', array( 'size' => 'twentysixteen-logo' ) );
+	add_theme_support( 'custom-logo', array( 'size' => 'twentysixteen-logo' ) );
 
 	/*
 	 * Enable support for Post Thumbnails on posts and pages.


### PR DESCRIPTION
See:
https://core.trac.wordpress.org/changeset/36837
https://core.trac.wordpress.org/ticket/35945
