### PR TITLE
Replace additional references to site logo with custom logo

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -65,7 +65,7 @@ function twentysixteen_setup() {
 	add_theme_support( 'title-tag' );
 
 	/*
-	 * Enable support for site logo.
+	 * Enable support for custom logo.
 	 */
 	add_image_size( 'twentysixteen-logo', 1200, 175 );
 	add_theme_support( 'custom-logo', array( 'size' => 'twentysixteen-logo' ) );
@@ -414,7 +414,7 @@ add_filter( 'widget_tag_cloud_args', 'twentysixteen_widget_tag_cloud_args' );
 
 /**
  * Add custom image sizes attribute to enhance responsive image functionality
- * for site logo.
+ * for custom logo.
  *
  * @since Twenty Sixteen 1.2
  *

--- a/header.php
+++ b/header.php
@@ -29,7 +29,7 @@
 		<header id="masthead" class="site-header" role="banner">
 			<div class="site-header-main">
 				<div class="site-branding">
-					<?php twentysixteen_the_site_logo(); ?>
+					<?php twentysixteen_the_custom_logo(); ?>
 
 					<?php if ( is_front_page() && is_home() ) : ?>
 						<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -236,19 +236,17 @@ function twentysixteen_category_transient_flusher() {
 add_action( 'edit_category', 'twentysixteen_category_transient_flusher' );
 add_action( 'save_post',     'twentysixteen_category_transient_flusher' );
 
-if ( ! function_exists( 'twentysixteen_the_site_logo' ) ) :
+if ( ! function_exists( 'twentysixteen_the_custom_logo' ) ) :
 /**
- * Displays the optional site logo.
+ * Displays the optional custom logo.
  *
- * Returns early if the site logo is not available.
+ * Does nothing if the custom logo is not available.
  *
  * @since Twenty Sixteen 1.2
  */
-function twentysixteen_the_site_logo() {
-	if ( ! function_exists( 'the_site_logo' ) ) {
-		return;
-	} else {
-		the_site_logo();
+function twentysixteen_the_custom_logo() {
+	if ( function_exists( 'the_custom_logo' ) ) {
+		the_custom_logo();
 	}
 }
 endif;

--- a/style.css
+++ b/style.css
@@ -1557,7 +1557,7 @@ blockquote:after,
 	margin: 0.875em auto 0.875em 0;
 }
 
-.site-logo-link {
+.custom-logo-link {
 	display: block;
 }
 


### PR DESCRIPTION
Commit https://github.com/xwp/twentysixteen/commit/fd788d5fd8b60a9c4a561c125e75e9d8d71321ca allowed the feature to re-appear in the Customizer, but selecting a Custom Logo wouldn't make it appear on the site since the other references to Site Logo weren't replaced with Custom Logo.

This PR does not address this, but there also seems to be some dead CSS rules using the `.wp-site-logo` body class which was removed in https://core.trac.wordpress.org/changeset/36837
