### PR TITLE
Make sure twentysixteen-logo image size is returned for Attachment model

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -430,3 +430,18 @@ function twentysixteen_logo_sizes_attr( $attr, $attachment, $size ) {
 	return $attr;
 }
 add_filter( 'wp_get_attachment_image_attributes', 'twentysixteen_logo_sizes_attr', 10 , 3 );
+
+/**
+ * Adds twentysixteen-logo to the recognized image sizes for media attachment model.
+ *
+ * @see wp_prepare_attachment_for_js()
+ * @since Twenty Sixteen 1.2
+ *
+ * @param array $size_names Image size names.
+ * @return array Image size names.
+ */
+function twentysixteen_logo_add_image_size_name( $size_names ) {
+	$size_names['twentysixteen-logo'] = __( 'Social Links Menu', 'twentysixteen' );
+	return $size_names;
+}
+add_filter( 'image_size_names_choose', 'twentysixteen_logo_add_image_size_name' );

--- a/functions.php
+++ b/functions.php
@@ -441,7 +441,7 @@ add_filter( 'wp_get_attachment_image_attributes', 'twentysixteen_logo_sizes_attr
  * @return array Image size names.
  */
 function twentysixteen_logo_add_image_size_name( $size_names ) {
-	$size_names['twentysixteen-logo'] = __( 'Social Links Menu', 'twentysixteen' );
+	$size_names['twentysixteen-logo'] = __( 'Twenty Sixteen Logo', 'twentysixteen' );
 	return $size_names;
 }
 add_filter( 'image_size_names_choose', 'twentysixteen_logo_add_image_size_name' );


### PR DESCRIPTION
This fixes an issue where an oversized image appears momentarily in the preview before the selective refresh request responds with the `img` tag rendered from the server. See https://youtu.be/JkQGhB_LzGo

It seems strange to be that all images sizes aren't returned by default from the media get-attachment Ajax request. Nevertheless, this fixes the issue.
