### PR TITLE
Rename wp-site-logo body class to wp-custom-logo

### DIFF
--- a/style.css
+++ b/style.css
@@ -1579,7 +1579,7 @@ blockquote:after,
 	color: #007acc;
 }
 
-.wp-site-logo .site-title {
+.wp-custom-logo .site-title {
 	margin-top: 0.608695652em;
 }
 
@@ -2745,7 +2745,7 @@ p > video {
 		line-height: 1.25;
 	}
 
-	.wp-site-logo .site-title {
+	.wp-custom-logo .site-title {
 		margin-top: 0.5em;
 	}
 
@@ -2938,7 +2938,7 @@ p > video {
 		align-items: flex-start;
 	}
 
-	.wp-site-logo .site-header-main {
+	.wp-custom-logo .site-header-main {
 		-webkit-align-items: center;
 		-ms-flex-align: center;
 		align-items: center;


### PR DESCRIPTION
This depends on this patch being committed to Core: https://core.trac.wordpress.org/attachment/ticket/35945/35945.restore-body-class.diff

See discussion starting at https://core.trac.wordpress.org/ticket/35945#comment:7
