### PR TITLE
Avoid overflowing wide custom logo in small screens in Firefox and IEs

### DIFF
--- a/style.css
+++ b/style.css
@@ -1555,6 +1555,10 @@ blockquote:after,
 
 .site-branding {
 	margin: 0.875em auto 0.875em 0;
+	/* Avoid overflowing wide custom logo in small screens in Firefox and IEs */
+	max-width: 100%;
+	min-width: 0;
+	overflow: hidden;
 }
 
 .custom-logo-link {


### PR DESCRIPTION
Fixes #440.

Tested with Chrome, Firefox (Latests), and IE11 - 7.
