### PR TITLE
Remove flex-width

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -73,7 +73,6 @@ function twentysixteen_setup() {
 		'height'      => 240,
 		'width'       => 240,
 		'flex-height' => true,
-		'flex-width'  => true,
 	) );
 
 	/*


### PR DESCRIPTION
Ref: https://core.trac.wordpress.org/ticket/36318

When the ticket above is closed, we don't need `flex-width` anymore.
