### PR TITLE
Increase site-description line-height

### DIFF
--- a/style.css
+++ b/style.css
@@ -1597,7 +1597,7 @@ blockquote:after,
 	font-size: 13px;
 	font-size: 0.8125rem;
 	font-weight: 400;
-	line-height: 1.0769230769;
+	line-height: 1.1769230769;
 	margin: 0.538461538em 0 0;
 }
 


### PR DESCRIPTION
To fix this small cut-off at the bottom of description, I would recommend increasing the line-height. Here's how this looks like: http://envato.d.pr/171h0/5HHngCXz

Please don't pay attention to what description says, this was for an internal project, not meant to be for this :)
