### PR TITLE
Remove white-space: pre-wrap; from <pre>

### DIFF
--- a/style.css
+++ b/style.css
@@ -404,7 +404,6 @@ pre {
 	overflow: auto;
 	padding: 1.75em;
 	white-space: pre;
-	white-space: pre-wrap;
 	word-wrap: break-word;
 }
 

--- a/style.css
+++ b/style.css
@@ -404,7 +404,7 @@ pre {
 	overflow: auto;
 	padding: 1.75em;
 	white-space: pre;
-	word-wrap: break-word;
+	word-wrap: normal;
 }
 
 code {


### PR DESCRIPTION
`white-space: pre-wrap` is fighting the rest of the CSS in this tag. Making any (lengthy) text or code wrapped in a `<pre>` is difficult to read.

![screenshot](https://dl.dropbox.com/s/oks11g796yldrlm/twentysixteen-remove-pre-wrap.gif?dl=0)

WP username: gregrickaby
