### PR TITLE
Fixed long site title cutoff

### DIFF
--- a/style.css
+++ b/style.css
@@ -1853,6 +1853,7 @@ a.post-thumbnail:focus {
 	margin-top: 0;
 }
 
+.site-title,
 .post-navigation .post-title,
 .entry-title,
 .comments-title {


### PR DESCRIPTION
Fixed [#3634 Twenty Sixteen/Fifteen/Thirteen/Twelve titles can lead to horizontal scrolls](https://core.trac.wordpress.org/ticket/36346).
Long 1word site title break with hyphen.

![site-title-add-hyphens](https://cloud.githubusercontent.com/assets/14228487/17198039/f8b0615c-54ac-11e6-9f9d-6004aaac2d05.png)
