### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+# Files to exclude when creating archive.
+
+*.git export-ignore
+*.gitignore export-ignore
+*.gitattributes export-ignore
+.jscsrc export-ignore
+.jshintignore export-ignore
+.travis.yml export-ignore
+CONTRIBUTING.md export-ignore
+CONTRIBUTORS.md export-ignore
+codesniffer.ruleset.xml export-ignore


### PR DESCRIPTION
This adds `.gitattributes` with [files which should be ignored](https://make.wordpress.org/core/handbook/about/release-cycle/update-bundled-themes/#twenty-sixteen) when running 'git archive' (https://git-scm.com/docs/git-archive).

`$ git archive --format=zip --output=twentysixteen.zip -9 --prefix=twentysixteen/ gitattributes` will then generate a ZIP file which is ready for an upload to the theme directory. (If you don't want to use the git command you can also use https://github.com/WordPress/twentysixteen/archive/master.zip.)
