### PR TITLE
Update CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -58,4 +58,4 @@ Version 1.3
 @davidakennedy 
 @ocean90 
 @grapplerulrich
-@josephfusco
+@joefusco


### PR DESCRIPTION
Contributions in 1.1 & 1.2 use my wordpress.org username but 1.3 shows my github.com username.
This makes all 3 mentions the same by using only the wordpress.org username.
