### PR TITLE
Improve post editor textarea margins

### DIFF
--- a/css/editor-style.css
+++ b/css/editor-style.css
@@ -28,7 +28,7 @@ body {
 	font-size: 16px;
 	font-weight: 400;
 	line-height: 1.75;
-	margin: 20px 40px;
+	margin: 10px 15px;
 	max-width: 600px;
 	vertical-align: baseline;
 }


### PR DESCRIPTION
In Twenty Sixteen, the left and right margins seem a-little large in the post content textarea, reducing the usable space for text.

Previously reported on Trac: https://core.trac.wordpress.org/ticket/37450
