### PR TITLE
Update editor-style.css: switch style of sup & sub

### DIFF
--- a/css/editor-style.css
+++ b/css/editor-style.css
@@ -223,11 +223,11 @@ sub {
 	vertical-align: baseline;
 }
 
-sub {
+sup {
 	top: -6px;
 }
 
-sup {
+sub {
 	bottom: -3px;
 }
 


### PR DESCRIPTION
Editor style for &lt;sup> and &lt;sub> are inversed, which causes &lt;sup> to be subscript and vice versa. This commit fixes this bug.