### PR TITLE
Fix category count when previewing with only 1 category

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -213,7 +213,7 @@ function twentysixteen_categorized_blog() {
 		set_transient( 'twentysixteen_categories', $all_the_cool_cats );
 	}
 
-	if ( $all_the_cool_cats > 1 ) {
+	if ( $all_the_cool_cats > 1 || is_preview() ) {
 		// This blog has more than 1 category so twentysixteen_categorized_blog should return true.
 		return true;
 	} else {


### PR DESCRIPTION
Matches relevant fix for Twenty Fourteen, Fifteen, and Seventeen: https://core.trac.wordpress.org/ticket/39531

#### Steps to repeat
1. Using a site with only the category, "Uncategorized, switch to Twenty Fourteen or Twenty Fifteen.
2. Create new post draft, and in the post meta box for Categories add a new category.
3. Save (don't publish), and Preview.
4. The new category will not be in the preview.
5. If you publish, the end result shows two categories, as expected.

#### What I expected
For the post preview to show the 2nd category I added, after saving the post.

#### What happened instead

The category is not shown in the preview. And because of how `twentysixteen_categorized_blog()` returns false for 1 or fewer categories, in this case it won't show the new category.

#### Screenshots

Before fix

<img width="1392" alt="screen shot 2017-01-10 at 10 18 51" src="https://cloud.githubusercontent.com/assets/66797/21816682/382670bc-d71e-11e6-839b-ef0b62f294a5.png">

After fix

<img width="1392" alt="screen shot 2017-01-10 at 10 18 41" src="https://cloud.githubusercontent.com/assets/66797/21816687/3c261fdc-d71e-11e6-9c84-ab332cb7df8c.png">
