### PR TITLE
remove BIND functionality for customizer in javascript

### DIFF
--- a/js/customize-preview.js
+++ b/js/customize-preview.js
@@ -11,20 +11,6 @@
 		                    .find( '#twentysixteen-color-scheme-css' );
 	}
 
-	// Site title.
-	api( 'blogname', function( value ) {
-		value.bind( function( to ) {
-			$( '.site-title a' ).text( to );
-		} );
-	} );
-
-	// Site tagline.
-	api( 'blogdescription', function( value ) {
-		value.bind( function( to ) {
-			$( '.site-description' ).text( to );
-		} );
-	} );
-
 	// Add custom-background-image body class when background image is added.
 	api( 'background_image', function( value ) {
 		value.bind( function( to ) {


### PR DESCRIPTION
We don't need to bind changed values in JavaScript to see changes instantly as we set `postMessage` for `.site-title` and `.site-description` to `selective_refresh` in the file `inc/customizer.php` on line `110` and `115`

and the following line of code will return `true` every time it get called
`if ( isset( $wp_customize->selective_refresh ) ) {` in customizer.php on line 109

the reason why it returns true is that this theme will only be available in `WordPress 4.4-alpha` or later according to this back-compatibility check in `functions.php` on line 31
`if ( version_compare( $GLOBALS['wp_version'], '4.4-alpha', '<' ) ) {`