### PR TITLE
Check for is_wp_error() before outputting tags.

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -101,7 +101,7 @@ function twentysixteen_entry_taxonomies() {
 	}
 
 	$tags_list = get_the_tag_list( '', _x( ', ', 'Used between list items, there is a space after the comma.', 'twentysixteen' ) );
-	if ( $tags_list ) {
+	if ( $tags_list && ! is_wp_error( $tags_list ) ) {
 		printf( '<span class="tags-links"><span class="screen-reader-text">%1$s </span>%2$s</span>',
 			_x( 'Tags', 'Used before tag names.', 'twentysixteen' ),
 			$tags_list


### PR DESCRIPTION
Check for `is_wp_error()` before outputting `get_the_tag_list()` to avoid potential fatal errors.

See: https://core.trac.wordpress.org/ticket/39860